### PR TITLE
[WIP] Remove f5networks.f5_modules dependency

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@ dependencies:
   cisco.intersight: '>=0.1.0'
   check_point.mgmt: '>=0.1.0'
   fortinet.fortios: '>=0.1.0'
-  f5networks.f5_modules: '>=0.1.0'
+#  f5networks.f5_modules: '>=0.1.0'
 repository: https://github.com/ansible-collections/community.network
 documentation: https://github.com/ansible-collection-migration/community.network/tree/master/docs
 homepage: https://github.com/ansible-collections/community.network

--- a/plugins/doc_fragments/_f5.py
+++ b/plugins/doc_fragments/_f5.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+    # Standard F5 documentation fragment
+    DOCUMENTATION = r'''
+options:
+  provider:
+    description:
+      - A dict object containing connection details.
+    type: dict
+    version_added: '2.5'
+    suboptions:
+      password:
+        description:
+          - The password for the user account used to connect to the BIG-IP.
+          - You may omit this option by setting the environment variable C(F5_PASSWORD).
+        type: str
+        required: true
+        aliases: [ pass, pwd ]
+      server:
+        description:
+          - The BIG-IP host.
+          - You may omit this option by setting the environment variable C(F5_SERVER).
+        type: str
+        required: true
+      server_port:
+        description:
+          - The BIG-IP server port.
+          - You may omit this option by setting the environment variable C(F5_SERVER_PORT).
+        type: int
+        default: 443
+      user:
+        description:
+          - The username to connect to the BIG-IP with. This user must have
+            administrative privileges on the device.
+          - You may omit this option by setting the environment variable C(F5_USER).
+        type: str
+        required: true
+      validate_certs:
+        description:
+          - If C(no), SSL certificates are not validated. Use this only
+            on personally controlled sites using self-signed certificates.
+          - You may omit this option by setting the environment variable C(F5_VALIDATE_CERTS).
+        type: bool
+        default: yes
+      timeout:
+        description:
+          - Specifies the timeout in seconds for communicating with the network device
+            for either connecting or sending commands.  If the timeout is
+            exceeded before the operation is completed, the module will error.
+        type: int
+      ssh_keyfile:
+        description:
+          - Specifies the SSH keyfile to use to authenticate the connection to
+            the remote device.  This argument is only used for I(cli) transports.
+          - You may omit this option by setting the environment variable C(ANSIBLE_NET_SSH_KEYFILE).
+        type: path
+      transport:
+        description:
+          - Configures the transport connection to use when connecting to the
+            remote device.
+        type: str
+        choices: [ cli, rest ]
+        default: rest
+      auth_provider:
+        description:
+          - Configures the auth provider for to obtain authentication tokens from the remote device.
+          - This option is really used when working with BIG-IQ devices.
+        type: str
+notes:
+  - For more information on using Ansible to manage F5 Networks devices see U(https://www.ansible.com/integrations/networks/f5).
+  - Requires BIG-IP software version >= 12.
+  - The F5 modules only manipulate the running configuration of the F5 product. To ensure that BIG-IP
+    specific configuration persists to disk, be sure to include at least one task that uses the
+    M(bigip_config) module to save the running configuration. Refer to the module's documentation for
+    the correct usage of the module to save your running configuration.
+'''

--- a/plugins/doc_fragments/_f5.py
+++ b/plugins/doc_fragments/_f5.py
@@ -2,6 +2,9 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 
 class ModuleDocFragment(object):
     # Standard F5 documentation fragment

--- a/plugins/module_utils/network/f5/_bigip.py
+++ b/plugins/module_utils/network/f5/_bigip.py
@@ -13,9 +13,9 @@ try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.icontrol import iControlRestSession
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import iControlRestSession
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import iControlRestSession
 
 
 class F5RestClient(F5BaseClient):

--- a/plugins/module_utils/network/f5/_bigip.py
+++ b/plugins/module_utils/network/f5/_bigip.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import time
+
+try:
+    from library.module_utils.network.f5.common import F5BaseClient
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.icontrol import iControlRestSession
+except ImportError:
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import iControlRestSession
+
+
+class F5RestClient(F5BaseClient):
+    def __init__(self, *args, **kwargs):
+        super(F5RestClient, self).__init__(*args, **kwargs)
+        self.provider = self.merge_provider_params()
+        self.headers = {
+            'Content-Type': 'application/json'
+        }
+        self.retries = 0
+
+    @property
+    def api(self):
+        if self._client:
+            return self._client
+        session, err = self.connect_via_token_auth()
+        if err or session is None:
+            session, err = self.connect_via_basic_auth()
+            if err or session is None:
+                raise F5ModuleError(err)
+        self._client = session
+        return session
+
+    def connect_via_token_auth(self):
+        url = "https://{0}:{1}/mgmt/shared/authn/login".format(
+            self.provider['server'], self.provider['server_port']
+        )
+        payload = {
+            'username': self.provider['user'],
+            'password': self.provider['password'],
+            'loginProviderName': self.provider['auth_provider'] or 'tmos'
+        }
+        session = iControlRestSession(
+            validate_certs=self.provider['validate_certs']
+        )
+
+        response = session.post(
+            url,
+            json=payload,
+            headers=self.headers
+        )
+
+        if response.status not in [200]:
+            if b'Configuration Utility restarting...' in response.content and self.retries < 3:
+                time.sleep(30)
+                self.retries += 1
+                return self.connect_via_token_auth()
+            else:
+                self.retries = 0
+                return None, response.content
+
+        self.retries = 0
+        session.request.headers['X-F5-Auth-Token'] = response.json()['token']['token']
+        return session, None
+
+    def connect_via_basic_auth(self):
+        url = "https://{0}:{1}/mgmt/tm/sys".format(
+            self.provider['server'], self.provider['server_port']
+        )
+        session = iControlRestSession(
+            url_username=self.provider['user'],
+            url_password=self.provider['password'],
+            validate_certs=self.provider['validate_certs'],
+        )
+
+        response = session.get(
+            url,
+            headers=self.headers
+        )
+
+        if response.status not in [200]:
+            if b'Configuration Utility restarting...' in response.content and self.retries < 3:
+                time.sleep(30)
+                self.retries += 1
+                return self.connect_via_basic_auth()
+            else:
+                self.retries = 0
+                return None, response.content
+        self.retries = 0
+        return session, None

--- a/plugins/module_utils/network/f5/_bigiq.py
+++ b/plugins/module_utils/network/f5/_bigiq.py
@@ -16,10 +16,10 @@ try:
     from library.module_utils.network.f5.common import is_ansible_debug
     from library.module_utils.network.f5.icontrol import iControlRestSession
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import is_ansible_debug
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import iControlRestSession
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import is_ansible_debug
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import iControlRestSession
 
 
 class F5RestClient(F5BaseClient):

--- a/plugins/module_utils/network/f5/_bigiq.py
+++ b/plugins/module_utils/network/f5/_bigiq.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import os
+
+
+try:
+    from library.module_utils.network.f5.common import F5BaseClient
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import is_ansible_debug
+    from library.module_utils.network.f5.icontrol import iControlRestSession
+except ImportError:
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import is_ansible_debug
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import iControlRestSession
+
+
+class F5RestClient(F5BaseClient):
+    def __init__(self, *args, **kwargs):
+        super(F5RestClient, self).__init__(*args, **kwargs)
+        self.provider = self.merge_provider_params()
+        self.headers = {
+            'Content-Type': 'application/json'
+        }
+
+    @property
+    def api(self):
+        if self._client:
+            return self._client
+        session, err = self.connect_via_token_auth()
+        if err:
+            raise F5ModuleError(err)
+        self._client = session
+        return session
+
+    def connect_via_token_auth(self):
+        provider = self.provider['auth_provider'] or 'local'
+
+        url = "https://{0}:{1}/mgmt/shared/authn/login".format(
+            self.provider['server'], self.provider['server_port']
+        )
+        payload = {
+            'username': self.provider['user'],
+            'password': self.provider['password'],
+        }
+
+        # - local is a special provider that is baked into the system and
+        #   has no loginReference
+        if provider != 'local':
+            login_ref = self.get_login_ref(provider)
+            payload.update(login_ref)
+
+        session = iControlRestSession(
+            validate_certs=self.provider['validate_certs']
+        )
+
+        response = session.post(
+            url,
+            json=payload,
+            headers=self.headers
+        )
+
+        if response.status not in [200]:
+            return None, response.content
+
+        session.request.headers['X-F5-Auth-Token'] = response.json()['token']['token']
+        return session, None
+
+    def get_login_ref(self, provider):
+        info = self.read_provider_info_from_device()
+        uuids = [os.path.basename(os.path.dirname(x['link'])) for x in info['providers'] if '-' in x['link']]
+        if provider in uuids:
+            name = self.get_name_of_provider_id(info, provider)
+            if not name:
+                raise F5ModuleError(
+                    "No name found for the provider '{0}'".format(provider)
+                )
+            return dict(
+                loginReference=dict(
+                    link="https://localhost/mgmt/cm/system/authn/providers/{0}/{1}/login".format(name, provider)
+                )
+            )
+        names = [os.path.basename(os.path.dirname(x['link'])) for x in info['providers'] if '-' in x['link']]
+        if names.count(provider) > 1:
+            raise F5ModuleError(
+                "Ambiguous auth_provider provided. Please specify a specific provider ID."
+            )
+        uuid = self.get_id_of_provider_name(info, provider)
+        if not uuid:
+            raise F5ModuleError(
+                "No name found for the provider '{0}'".format(provider)
+            )
+        return dict(
+            loginReference=dict(
+                link="https://localhost/mgmt/cm/system/authn/providers/{0}/{1}/login".format(provider, uuid)
+            )
+        )
+
+    def get_name_of_provider_id(self, info, provider):
+        # Add slashes to the provider name so that it specifically finds the provider
+        # as part of the URL and not a part of another substring
+        provider = '/' + provider + '/'
+        for x in info['providers']:
+            if x['link'].find(provider) > -1:
+                return x['name']
+        return None
+
+    def get_id_of_provider_name(self, info, provider):
+        for x in info['providers']:
+            if x['name'] == provider:
+                return os.path.basename(os.path.dirname(x['link']))
+        return None
+
+    def read_provider_info_from_device(self):
+        uri = "https://{0}:{1}/info/system".format(
+            self.provider['server'], self.provider['server_port']
+        )
+        session = iControlRestSession()
+        session.verify = self.provider['validate_certs']
+
+        resp = session.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return response

--- a/plugins/module_utils/network/f5/_common.py
+++ b/plugins/module_utils/network/f5/_common.py
@@ -1,0 +1,573 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import copy
+import os
+import re
+import datetime
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.connection import exec_command
+from ansible.module_utils.network.common.utils import to_list
+from ansible.module_utils.network.common.utils import ComplexList
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE
+from collections import defaultdict
+
+
+MANAGED_BY_ANNOTATION_VERSION = 'f5-ansible.version'
+MANAGED_BY_ANNOTATION_MODIFIED = 'f5-ansible.last_modified'
+
+
+f5_provider_spec = {
+    'server': dict(
+        fallback=(env_fallback, ['F5_SERVER'])
+    ),
+    'server_port': dict(
+        type='int',
+        default=443,
+        fallback=(env_fallback, ['F5_SERVER_PORT'])
+    ),
+    'user': dict(
+        fallback=(env_fallback, ['F5_USER', 'ANSIBLE_NET_USERNAME'])
+    ),
+    'password': dict(
+        no_log=True,
+        aliases=['pass', 'pwd'],
+        fallback=(env_fallback, ['F5_PASSWORD', 'ANSIBLE_NET_PASSWORD'])
+    ),
+    'ssh_keyfile': dict(
+        type='path'
+    ),
+    'validate_certs': dict(
+        type='bool',
+        default='yes',
+        fallback=(env_fallback, ['F5_VALIDATE_CERTS'])
+    ),
+    'transport': dict(
+        choices=['cli', 'rest'],
+        default='rest'
+    ),
+    'timeout': dict(type='int'),
+    'auth_provider': dict(),
+}
+
+f5_argument_spec = {
+    'provider': dict(type='dict', options=f5_provider_spec),
+}
+
+
+def get_provider_argspec():
+    return f5_provider_spec
+
+
+def load_params(params):
+    provider = params.get('provider') or dict()
+    for key, value in iteritems(provider):
+        if key in f5_argument_spec:
+            if params.get(key) is None and value is not None:
+                params[key] = value
+
+
+def is_empty_list(seq):
+    if len(seq) == 1:
+        if seq[0] == '' or seq[0] == 'none':
+            return True
+    return False
+
+
+def fq_name(partition, value, sub_path=''):
+    """Returns a 'Fully Qualified' name
+
+    A BIG-IP expects most names of resources to be in a fully-qualified
+    form. This means that both the simple name, and the partition need
+    to be combined.
+
+    The Ansible modules, however, can accept (as names for several
+    resources) their name in the FQ format. This becomes an issue when
+    the FQ name and the partition are both specified as separate values.
+
+    Consider the following examples.
+
+        # Name not FQ
+        name: foo
+        partition: Common
+
+        # Name FQ
+        name: /Common/foo
+        partition: Common
+
+    This method will rectify the above situation and will, in both cases,
+    return the following for name.
+
+        /Common/foo
+
+    Args:
+        partition (string): The partition that you would want attached to
+            the name if the name has no partition.
+        value (string): The name that you want to attach a partition to.
+            This value will be returned unchanged if it has a partition
+            attached to it already.
+        sub_path (string): The sub path element. If defined the sub_path
+            will be inserted between partition and value.
+            This will also work on FQ names.
+    Returns:
+        string: The fully qualified name, given the input parameters.
+    """
+    if value is not None and sub_path == '':
+        try:
+            int(value)
+            return '/{0}/{1}'.format(partition, value)
+        except (ValueError, TypeError):
+            if not value.startswith('/'):
+                return '/{0}/{1}'.format(partition, value)
+    if value is not None and sub_path != '':
+        try:
+            int(value)
+            return '/{0}/{1}/{2}'.format(partition, sub_path, value)
+        except (ValueError, TypeError):
+            if value.startswith('/'):
+                dummy, partition, name = value.split('/')
+                return '/{0}/{1}/{2}'.format(partition, sub_path, name)
+            if not value.startswith('/'):
+                return '/{0}/{1}/{2}'.format(partition, sub_path, value)
+    return value
+
+
+# Fully Qualified name (with partition) for a list
+def fq_list_names(partition, list_names):
+    if list_names is None:
+        return None
+    return map(lambda x: fq_name(partition, x), list_names)
+
+
+def to_commands(module, commands):
+    spec = {
+        'command': dict(key=True),
+        'prompt': dict(),
+        'answer': dict()
+    }
+    transform = ComplexList(spec, module)
+    return transform(commands)
+
+
+def run_commands(module, commands, check_rc=True):
+    responses = list()
+    commands = to_commands(module, to_list(commands))
+    for cmd in commands:
+        cmd = module.jsonify(cmd)
+        rc, out, err = exec_command(module, cmd)
+        if check_rc and rc != 0:
+            raise F5ModuleError(to_text(err, errors='surrogate_then_replace'))
+        result = to_text(out, errors='surrogate_then_replace')
+        responses.append(result)
+    return responses
+
+
+def flatten_boolean(value):
+    truthy = list(BOOLEANS_TRUE) + ['enabled', 'True', 'true']
+    falsey = list(BOOLEANS_FALSE) + ['disabled', 'False', 'false']
+    if value is None:
+        return None
+    elif value in truthy:
+        return 'yes'
+    elif value in falsey:
+        return 'no'
+
+
+def is_cli(module):
+    transport = module.params['transport']
+    provider_transport = (module.params['provider'] or {}).get('transport')
+    result = 'cli' in (transport, provider_transport)
+    return result
+
+
+def is_valid_hostname(host):
+    """Reasonable attempt at validating a hostname
+
+    Compiled from various paragraphs outlined here
+    https://tools.ietf.org/html/rfc3696#section-2
+    https://tools.ietf.org/html/rfc1123
+
+    Notably,
+    * Host software MUST handle host names of up to 63 characters and
+      SHOULD handle host names of up to 255 characters.
+    * The "LDH rule", after the characters that it permits. (letters, digits, hyphen)
+    * If the hyphen is used, it is not permitted to appear at
+      either the beginning or end of a label
+
+    :param host:
+    :return:
+    """
+    if len(host) > 255:
+        return False
+    host = host.rstrip(".")
+    allowed = re.compile(r'(?!-)[A-Z0-9-]{1,63}(?<!-)$', re.IGNORECASE)
+    result = all(allowed.match(x) for x in host.split("."))
+    return result
+
+
+def is_valid_fqdn(host):
+    """Reasonable attempt at validating a hostname
+
+    Compiled from various paragraphs outlined here
+    https://tools.ietf.org/html/rfc3696#section-2
+    https://tools.ietf.org/html/rfc1123
+
+    Notably,
+    * Host software MUST handle host names of up to 63 characters and
+      SHOULD handle host names of up to 255 characters.
+    * The "LDH rule", after the characters that it permits. (letters, digits, hyphen)
+    * If the hyphen is used, it is not permitted to appear at
+      either the beginning or end of a label
+
+    :param host:
+    :return:
+    """
+    if len(host) > 255:
+        return False
+    host = host.rstrip(".")
+    allowed = re.compile(r'(?!-)[A-Z0-9-]{1,63}(?<!-)$', re.IGNORECASE)
+    result = all(allowed.match(x) for x in host.split("."))
+    if result:
+        parts = host.split('.')
+        if len(parts) > 1:
+            return True
+    return False
+
+
+def transform_name(partition='', name='', sub_path=''):
+    if partition != '':
+        if name.startswith(partition + '/'):
+            name = name.replace(partition + '/', '')
+        if name.startswith('/' + partition + '/'):
+            name = name.replace('/' + partition + '/', '')
+
+    if name:
+        name = name.replace('/', '~')
+        name = name.replace('%', '%25')
+
+    if partition:
+        partition = partition.replace('/', '~')
+        if not partition.startswith('~'):
+            partition = '~' + partition
+    else:
+        if sub_path:
+            raise F5ModuleError(
+                'When giving the subPath component include partition as well.'
+            )
+
+    if sub_path and partition:
+        sub_path = '~' + sub_path
+
+    if name and partition:
+        name = '~' + name
+
+    result = partition + sub_path + name
+    return result
+
+
+def is_ansible_debug(module):
+    if module._debug and module._verbosity >= 4:
+        return True
+    return False
+
+
+def is_uuid(uuid=None):
+    """Check to see if value is an F5 UUID
+
+    UUIDs are used in BIG-IQ and in select areas of BIG-IP (notably ASM). This method
+    will check to see if the provided value matches a UUID as known by these products.
+
+    Args:
+        uuid (string): The value to check for UUID-ness
+
+    Returns:
+        bool:
+    """
+    if uuid is None:
+        return False
+    pattern = r'[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}'
+    if re.match(pattern, uuid):
+        return True
+    return False
+
+
+def on_bigip():
+    if os.path.exists('/usr/bin/tmsh'):
+        return True
+    return False
+
+
+def mark_managed_by(ansible_version, params):
+    metadata = []
+    result = copy.deepcopy(params)
+    found1 = False
+    found2 = False
+    mark1 = dict(
+        name=MANAGED_BY_ANNOTATION_VERSION,
+        value=ansible_version,
+        persist='true'
+    )
+    mark2 = dict(
+        name=MANAGED_BY_ANNOTATION_MODIFIED,
+        value=str(datetime.datetime.utcnow()),
+        persist='true'
+    )
+
+    if 'metadata' not in result:
+        result['metadata'] = [mark1, mark2]
+        return result
+
+    for x in params['metadata']:
+        if x['name'] == MANAGED_BY_ANNOTATION_VERSION:
+            found1 = True
+            metadata.append(mark1)
+        if x['name'] == MANAGED_BY_ANNOTATION_MODIFIED:
+            found2 = True
+            metadata.append(mark1)
+        else:
+            metadata.append(x)
+    if not found1:
+        metadata.append(mark1)
+    if not found2:
+        metadata.append(mark2)
+
+    result['metadata'] = metadata
+    return result
+
+
+def only_has_managed_metadata(metadata):
+    managed = [
+        MANAGED_BY_ANNOTATION_MODIFIED,
+        MANAGED_BY_ANNOTATION_VERSION,
+    ]
+
+    for x in metadata:
+        if x['name'] not in managed:
+            return False
+    return True
+
+
+class Noop(object):
+    """Represent no-operation required
+
+    This class is used in the Difference engine to specify when an attribute
+    has not changed. Difference attributes may return an instance of this
+    class as a means to indicate when the attribute has not changed.
+
+    The Noop object allows attributes to be set to None when sending updates
+    to the API. `None` is technically a valid value in some cases (it indicates
+    that the attribute should be removed from the resource).
+    """
+    pass
+
+
+class F5BaseClient(object):
+    def __init__(self, *args, **kwargs):
+        self.params = kwargs
+        self.module = kwargs.get('module', None)
+        load_params(self.params)
+        self._client = None
+
+    @property
+    def api(self):
+        raise F5ModuleError("Management root must be used from the concrete product classes.")
+
+    def reconnect(self):
+        """Attempts to reconnect to a device
+
+        The existing token from a ManagementRoot can become invalid if you,
+        for example, upgrade the device (such as is done in the *_software
+        module.
+
+        This method can be used to reconnect to a remote device without
+        having to re-instantiate the ArgumentSpec and AnsibleF5Client classes
+        it will use the same values that were initially provided to those
+        classes
+
+        :return:
+        :raises iControlUnexpectedHTTPError
+        """
+        self._client = None
+
+    @staticmethod
+    def validate_params(key, store):
+        if key in store and store[key] is not None:
+            return True
+        else:
+            return False
+
+    def merge_provider_params(self):
+        result = dict()
+        provider = self.params.get('provider', None)
+        if not provider:
+            provider = {}
+
+        self.merge_provider_server_param(result, provider)
+        self.merge_provider_server_port_param(result, provider)
+        self.merge_provider_validate_certs_param(result, provider)
+        self.merge_provider_auth_provider_param(result, provider)
+        self.merge_provider_user_param(result, provider)
+        self.merge_provider_password_param(result, provider)
+
+        return result
+
+    def merge_provider_server_param(self, result, provider):
+        if self.validate_params('server', provider):
+            result['server'] = provider['server']
+        elif self.validate_params('F5_SERVER', os.environ):
+            result['server'] = os.environ['F5_SERVER']
+        else:
+            raise F5ModuleError('Server parameter cannot be None or missing, please provide a valid value')
+
+    def merge_provider_server_port_param(self, result, provider):
+        if self.validate_params('server_port', provider):
+            result['server_port'] = provider['server_port']
+        elif self.validate_params('F5_SERVER_PORT', os.environ):
+            result['server_port'] = os.environ['F5_SERVER_PORT']
+        else:
+            result['server_port'] = 443
+
+    def merge_provider_validate_certs_param(self, result, provider):
+        if self.validate_params('validate_certs', provider):
+            result['validate_certs'] = provider['validate_certs']
+        elif self.validate_params('F5_VALIDATE_CERTS', os.environ):
+            result['validate_certs'] = os.environ['F5_VALIDATE_CERTS']
+        else:
+            result['validate_certs'] = True
+        if result['validate_certs'] in BOOLEANS_TRUE:
+            result['validate_certs'] = True
+        else:
+            result['validate_certs'] = False
+
+    def merge_provider_auth_provider_param(self, result, provider):
+        if self.validate_params('auth_provider', provider):
+            result['auth_provider'] = provider['auth_provider']
+        elif self.validate_params('F5_AUTH_PROVIDER', os.environ):
+            result['auth_provider'] = os.environ['F5_AUTH_PROVIDER']
+        else:
+            result['auth_provider'] = None
+
+        # Handle a specific case of the user specifying ``|default(omit)``
+        # as the value to the auth_provider.
+        #
+        # In this case, Ansible will inject the omit-placeholder value
+        # and the module params incorrectly interpret this. This case
+        # can occur when specifying ``|default(omit)`` for a variable
+        # value defined in the ``environment`` section of a Play.
+        #
+        # An example of the omit placeholder is shown below.
+        #
+        #  __omit_place_holder__11bd71a2840bff144594b9cc2149db814256f253
+        #
+        if result['auth_provider'] is not None and '__omit_place_holder__' in result['auth_provider']:
+            result['auth_provider'] = None
+
+    def merge_provider_user_param(self, result, provider):
+        if self.validate_params('user', provider):
+            result['user'] = provider['user']
+        elif self.validate_params('F5_USER', os.environ):
+            result['user'] = os.environ.get('F5_USER')
+        elif self.validate_params('ANSIBLE_NET_USERNAME', os.environ):
+            result['user'] = os.environ.get('ANSIBLE_NET_USERNAME')
+        else:
+            result['user'] = None
+
+    def merge_provider_password_param(self, result, provider):
+        if self.validate_params('password', provider):
+            result['password'] = provider['password']
+        elif self.validate_params('F5_PASSWORD', os.environ):
+            result['password'] = os.environ.get('F5_PASSWORD')
+        elif self.validate_params('ANSIBLE_NET_PASSWORD', os.environ):
+            result['password'] = os.environ.get('ANSIBLE_NET_PASSWORD')
+        else:
+            result['password'] = None
+
+
+class AnsibleF5Parameters(object):
+    def __init__(self, *args, **kwargs):
+        self._values = defaultdict(lambda: None)
+        self._values['__warnings'] = []
+        self.client = kwargs.pop('client', None)
+        self._module = kwargs.pop('module', None)
+        self._params = {}
+
+        params = kwargs.pop('params', None)
+        if params:
+            self.update(params=params)
+            self._params.update(params)
+
+    def update(self, params=None):
+        if params:
+            self._params.update(params)
+            for k, v in iteritems(params):
+                # Adding this here because ``username`` is a connection parameter
+                # and in cases where it is also an API parameter, we run the risk
+                # of overriding the specified parameter with the connection parameter.
+                #
+                # Since this is a problem, and since "username" is never a valid
+                # parameter outside its usage in connection params (where we do not
+                # use the ApiParameter or ModuleParameters classes) it is safe to
+                # skip over it if it is provided.
+                if k == 'password':
+                    continue
+                if self.api_map is not None and k in self.api_map:
+                    map_key = self.api_map[k]
+                else:
+                    map_key = k
+
+                # Handle weird API parameters like `dns.proxy.__iter__` by
+                # using a map provided by the module developer
+                class_attr = getattr(type(self), map_key, None)
+                if isinstance(class_attr, property):
+                    # There is a mapped value for the api_map key
+                    if class_attr.fset is None:
+                        # If the mapped value does not have
+                        # an associated setter
+                        self._values[map_key] = v
+                    else:
+                        # The mapped value has a setter
+                        setattr(self, map_key, v)
+                else:
+                    # If the mapped value is not a @property
+                    self._values[map_key] = v
+
+    def api_params(self):
+        result = {}
+        for api_attribute in self.api_attributes:
+            if self.api_map is not None and api_attribute in self.api_map:
+                result[api_attribute] = getattr(self, self.api_map[api_attribute])
+            else:
+                result[api_attribute] = getattr(self, api_attribute)
+        result = self._filter_params(result)
+        return result
+
+    def __getattr__(self, item):
+        # Ensures that properties that weren't defined, and therefore stashed
+        # in the `_values` dict, will be retrievable.
+        return self._values[item]
+
+    @property
+    def partition(self):
+        if self._values['partition'] is None:
+            return 'Common'
+        return self._values['partition'].strip('/')
+
+    @partition.setter
+    def partition(self, value):
+        self._values['partition'] = value
+
+    def _filter_params(self, params):
+        return dict((k, v) for k, v in iteritems(params) if v is not None)
+
+
+class F5ModuleError(Exception):
+    pass

--- a/plugins/module_utils/network/f5/_common.py
+++ b/plugins/module_utils/network/f5/_common.py
@@ -14,8 +14,8 @@ import datetime
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.connection import exec_command
-from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.network.common.utils import ComplexList
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE

--- a/plugins/module_utils/network/f5/_compare.py
+++ b/plugins/module_utils/network/f5/_compare.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.six import iteritems
+
+
+def cmp_simple_list(want, have):
+    if want is None:
+        return None
+    if have is None and want in ['', 'none']:
+        return None
+    if have is not None and want in ['', 'none']:
+        return []
+    if have is None:
+        return want
+    if set(want) != set(have):
+        return want
+    return None
+
+
+def cmp_str_with_none(want, have):
+    if want is None:
+        return None
+    if have is None and want == '':
+        return None
+    if want != have:
+        return want
+
+
+def compare_complex_list(want, have):
+    """Performs a complex list comparison
+
+    A complex list is a list of dictionaries
+
+    Args:
+        want (list): List of dictionaries to compare with second parameter.
+        have (list): List of dictionaries compare with first parameter.
+
+    Returns:
+        bool:
+    """
+    if want == [] and have is None:
+        return None
+    if want is None:
+        return None
+    w = []
+    h = []
+    for x in want:
+        tmp = [(str(k), str(v)) for k, v in iteritems(x)]
+        w += tmp
+    for x in have:
+        tmp = [(str(k), str(v)) for k, v in iteritems(x)]
+        h += tmp
+    if set(w) == set(h):
+        return None
+    else:
+        return want
+
+
+def compare_dictionary(want, have):
+    """Performs a dictionary comparison
+
+    Args:
+        want (dict): Dictionary to compare with second parameter.
+        have (dict): Dictionary to compare with first parameter.
+
+    Returns:
+        bool:
+    """
+    if want == {} and have is None:
+        return None
+    if want is None:
+        return None
+    w = [(str(k), str(v)) for k, v in iteritems(want)]
+    h = [(str(k), str(v)) for k, v in iteritems(have)]
+    if set(w) == set(h):
+        return None
+    else:
+        return want

--- a/plugins/module_utils/network/f5/_icontrol.py
+++ b/plugins/module_utils/network/f5/_icontrol.py
@@ -1,0 +1,612 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017, F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import os
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+try:
+    from BytesIO import BytesIO
+except ImportError:
+    from io import BytesIO
+
+from ansible.module_utils.urls import urlparse
+from ansible.module_utils.urls import generic_urlparse
+from ansible.module_utils.urls import Request
+
+try:
+    import json as _json
+except ImportError:
+    import simplejson as _json
+
+try:
+    from library.module_utils.network.f5.common import F5ModuleError
+except ImportError:
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+
+
+"""An F5 REST API URI handler.
+
+Use this module to make calls to an F5 REST server. It is influenced by the same
+API that the Python ``requests`` tool uses, but the two are not the same, as the
+library here is **much** more simple and targeted specifically to F5's needs.
+
+The ``requests`` design was chosen due to familiarity with the tool. Internally,
+the classes contained herein use Ansible native libraries.
+
+The means by which you should use it are similar to ``requests`` basic usage.
+
+Authentication is not handled for you automatically by this library, however it *is*
+handled automatically for you in the supporting F5 module_utils code; specifically the
+different product module_util files (bigip.py, bigiq.py, etc).
+
+Internal (non-module) usage of this library looks like this.
+
+```
+# Create a session instance
+mgmt = iControlRestSession()
+mgmt.verify = False
+
+server = '1.1.1.1'
+port = 443
+
+# Payload used for getting an initial authentication token
+payload = {
+  'username': 'admin',
+  'password': 'secret',
+  'loginProviderName': 'tmos'
+}
+
+# Create URL to call, injecting server and port
+url = f"https://{server}:{port}/mgmt/shared/authn/login"
+
+# Call the API
+resp = session.post(url, json=payload)
+
+# View the response
+print(resp.json())
+
+# Update the session with the authentication token
+session.headers['X-F5-Auth-Token'] = resp.json()['token']['token']
+
+# Create another URL to call, injecting server and port
+url = f"https://{server}:{port}/mgmt/tm/ltm/virtual/~Common~virtual1"
+
+# Call the API
+resp = session.get(url)
+
+# View the details of a virtual payload
+print(resp.json())
+```
+"""
+
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+
+class Response(object):
+    def __init__(self):
+        self._content = None
+        self.status = None
+        self.headers = dict()
+        self.url = None
+        self.reason = None
+        self.request = None
+        self.msg = None
+
+    @property
+    def content(self):
+        return self._content
+
+    @property
+    def raw_content(self):
+        return self._content
+
+    def json(self):
+        return _json.loads(self._content or 'null')
+
+    @property
+    def ok(self):
+        if self.status is not None and int(self.status) > 400:
+            return False
+        try:
+            response = self.json()
+            if 'code' in response and response['code'] > 400:
+                return False
+        except ValueError:
+            pass
+        return True
+
+
+class iControlRestSession(object):
+    """Represents a session that communicates with a BigIP.
+
+    This acts as a loose wrapper around Ansible's ``Request`` class. We're doing
+    this as interim work until we move to the httpapi connector.
+    """
+    def __init__(self, headers=None, use_proxy=True, force=False, timeout=120,
+                 validate_certs=True, url_username=None, url_password=None,
+                 http_agent=None, force_basic_auth=False, follow_redirects='urllib2',
+                 client_cert=None, client_key=None, cookies=None):
+        self.request = Request(
+            headers=headers,
+            use_proxy=use_proxy,
+            force=force,
+            timeout=timeout,
+            validate_certs=validate_certs,
+            url_username=url_username,
+            url_password=url_password,
+            http_agent=http_agent,
+            force_basic_auth=force_basic_auth,
+            follow_redirects=follow_redirects,
+            client_cert=client_cert,
+            client_key=client_key,
+            cookies=cookies
+        )
+        self.last_url = None
+
+    def get_headers(self, result):
+        try:
+            return dict(result.getheaders())
+        except AttributeError:
+            return result.headers
+
+    def update_response(self, response, result):
+        response.headers = self.get_headers(result)
+        response._content = result.read()
+        response.status = result.getcode()
+        response.url = result.geturl()
+        response.msg = "OK (%s bytes)" % response.headers.get('Content-Length', 'unknown')
+
+    def send(self, method, url, **kwargs):
+        response = Response()
+
+        # Set the last_url called
+        #
+        # This is used by the object destructor to erase the token when the
+        # ModuleManager exits and destroys the iControlRestSession object
+        self.last_url = url
+
+        body = None
+        data = kwargs.pop('data', None)
+        json = kwargs.pop('json', None)
+
+        if not data and json is not None:
+            self.request.headers['Content-Type'] = 'application/json'
+            body = _json.dumps(json)
+            if not isinstance(body, bytes):
+                body = body.encode('utf-8')
+        if data:
+            body = data
+        if body:
+            kwargs['data'] = body
+
+        try:
+            result = self.request.open(method, url, **kwargs)
+        except HTTPError as e:
+            # Catch HTTPError delivered from Ansible
+            #
+            # The structure of this object, in Ansible 2.8 is
+            #
+            # HttpError {
+            #   args
+            #   characters_written
+            #   close
+            #   code
+            #   delete
+            #   errno
+            #   file
+            #   filename
+            #   filename2
+            #   fp
+            #   getcode
+            #   geturl
+            #   hdrs
+            #   headers
+            #   info
+            #   msg
+            #   name
+            #   reason
+            #   strerror
+            #   url
+            #   with_traceback
+            # }
+            self.update_response(response, e)
+            return response
+
+        self.update_response(response, result)
+        return response
+
+    def delete(self, url, **kwargs):
+        return self.send('DELETE', url, **kwargs)
+
+    def get(self, url, **kwargs):
+        return self.send('GET', url, **kwargs)
+
+    def patch(self, url, data=None, **kwargs):
+        return self.send('PATCH', url, data=data, **kwargs)
+
+    def post(self, url, data=None, **kwargs):
+        return self.send('POST', url, data=data, **kwargs)
+
+    def put(self, url, data=None, **kwargs):
+        return self.send('PUT', url, data=data, **kwargs)
+
+    def __del__(self):
+        if self.last_url is None:
+            return
+        token = self.request.headers.get('X-F5-Auth-Token', None)
+        if not token:
+            return
+        try:
+            p = generic_urlparse(urlparse(self.last_url))
+            uri = "https://{0}:{1}/mgmt/shared/authz/tokens/{2}".format(
+                p['hostname'], p['port'], token
+            )
+            self.delete(uri)
+        except ValueError:
+            pass
+
+
+class TransactionContextManager(object):
+    def __init__(self, client, validate_only=False):
+        self.client = client
+        self.validate_only = validate_only
+        self.transid = None
+
+    def __enter__(self):
+        uri = "https://{0}:{1}/mgmt/tm/transaction/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        resp = self.client.api.post(uri, json={})
+        if resp.status not in [200]:
+            raise Exception
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        self.transid = response['transId']
+        self.client.api.request.headers['X-F5-REST-Coordination-Id'] = self.transid
+        return self.client
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.client.api.request.headers.pop('X-F5-REST-Coordination-Id')
+        if exc_tb is None:
+            uri = "https://{0}:{1}/mgmt/tm/transaction/{2}".format(
+                self.client.provider['server'],
+                self.client.provider['server_port'],
+                self.transid
+            )
+            params = dict(
+                state="VALIDATING",
+                validateOnly=self.validate_only
+            )
+            resp = self.client.api.patch(uri, json=params)
+            if resp.status not in [200]:
+                raise Exception
+
+
+def download_asm_file(client, url, dest):
+    """Download an ASM file from the remote device
+
+    This method handles issues with ASM file endpoints that allow
+    downloads of ASM objects on the BIG-IP.
+
+    Arguments:
+        client (object): The F5RestClient connection object.
+        url (string): The URL to download.
+        dest (string): The location on (Ansible controller) disk to store the file.
+
+    Returns:
+        bool: True on success. False otherwise.
+    """
+
+    with open(dest, 'wb') as fileobj:
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        data = {'headers': headers,
+                'verify': False
+                }
+
+        response = client.api.get(url, headers=headers, json=data)
+        if response.status == 200:
+            if 'Content-Length' not in response.headers:
+                error_message = "The Content-Length header is not present."
+                raise F5ModuleError(error_message)
+
+            length = response.headers['Content-Length']
+
+            if int(length) > 0:
+                fileobj.write(response.content)
+            else:
+                error = "Invalid Content-Length value returned: %s ," \
+                        "the value should be greater than 0" % length
+                raise F5ModuleError(error)
+
+
+def download_file(client, url, dest):
+    """Download a file from the remote device
+
+    This method handles the chunking needed to download a file from
+    a given URL on the BIG-IP.
+
+    Arguments:
+        client (object): The F5RestClient connection object.
+        url (string): The URL to download.
+        dest (string): The location on (Ansible controller) disk to store the file.
+
+    Returns:
+        bool: True on success. False otherwise.
+    """
+    with open(dest, 'wb') as fileobj:
+        chunk_size = 512 * 1024
+        start = 0
+        end = chunk_size - 1
+        size = 0
+        current_bytes = 0
+
+        while True:
+            content_range = "%s-%s/%s" % (start, end, size)
+            headers = {
+                'Content-Range': content_range,
+                'Content-Type': 'application/octet-stream'
+            }
+            data = {
+                'headers': headers,
+                'verify': False,
+                'stream': False
+            }
+            response = client.api.get(url, headers=headers, json=data)
+            if response.status == 200:
+                # If the size is zero, then this is the first time through
+                # the loop and we don't want to write data because we
+                # haven't yet figured out the total size of the file.
+                if size > 0:
+                    current_bytes += chunk_size
+                    fileobj.write(response.raw_content)
+            # Once we've downloaded the entire file, we can break out of
+            # the loop
+            if end == size:
+                break
+            crange = response.headers['Content-Range']
+            # Determine the total number of bytes to read.
+            if size == 0:
+                size = int(crange.split('/')[-1]) - 1
+                # If the file is smaller than the chunk_size, the BigIP
+                # will return an HTTP 400. Adjust the chunk_size down to
+                # the total file size...
+                if chunk_size > size:
+                    end = size
+                # ...and pass on the rest of the code.
+                continue
+            start += chunk_size
+            if (current_bytes + chunk_size) > size:
+                end = size
+            else:
+                end = start + chunk_size - 1
+    return True
+
+
+def upload_file(client, url, src, dest=None):
+    """Upload a file to an arbitrary URL.
+
+    This method is responsible for correctly chunking an upload request to an
+    arbitrary file worker URL.
+
+    Arguments:
+        client (object): The F5RestClient connection object.
+        url (string): The URL to upload a file to.
+        src (string): The file to be uploaded.
+        dest (string): The file name to create on the remote device.
+
+    Examples:
+        The ``dest`` may be either an absolute or relative path. The basename
+        of the path is used as the remote file name upon upload. For instance,
+        in the example below, ``BIGIP-13.1.0.8-0.0.3.iso`` would be the name
+        of the remote file.
+
+        The specified URL should be the full URL to where you want to upload a
+        file. BIG-IP has many different URLs that can be used to handle different
+        types of files. This is why a full URL is required.
+
+        >>> from ansible_collections.community.network.plugins.module_utils.f5._icontrol import upload_client
+        >>> url = 'https://{0}:{1}/mgmt/cm/autodeploy/software-image-uploads'.format(
+        ...   self.client.provider['server'],
+        ...   self.client.provider['server_port']
+        ... )
+        >>> dest = '/path/to/BIGIP-13.1.0.8-0.0.3.iso'
+        >>> upload_file(self.client, url, dest)
+        True
+
+    Returns:
+        bool: True on success. False otherwise.
+
+    Raises:
+        F5ModuleError: Raised if ``retries`` limit is exceeded.
+    """
+    if isinstance(src, StringIO) or isinstance(src, BytesIO):
+        fileobj = src
+    else:
+        fileobj = open(src, 'rb')
+
+    try:
+        size = os.stat(src).st_size
+        is_file = True
+    except TypeError:
+        src.seek(0, os.SEEK_END)
+        size = src.tell()
+        src.seek(0)
+        is_file = False
+
+    # This appears to be the largest chunk size that iControlREST can handle.
+    #
+    # The trade-off you are making by choosing a chunk size is speed, over size of
+    # transmission. A lower chunk size will be slower because a smaller amount of
+    # data is read from disk and sent via HTTP. Lots of disk reads are slower and
+    # There is overhead in sending the request to the BIG-IP.
+    #
+    # Larger chunk sizes are faster because more data is read from disk in one
+    # go, and therefore more data is transmitted to the BIG-IP in one HTTP request.
+    #
+    # If you are transmitting over a slow link though, it may be more reliable to
+    # transmit many small chunks that fewer large chunks. It will clearly take
+    # longer, but it may be more robust.
+    chunk_size = 1024 * 7168
+    start = 0
+    retries = 0
+    if dest is None and is_file:
+        basename = os.path.basename(src)
+    else:
+        basename = dest
+    url = '{0}/{1}'.format(url.rstrip('/'), basename)
+
+    while True:
+        if retries == 3:
+            # Retries are used here to allow the REST API to recover if you kill
+            # an upload mid-transfer.
+            #
+            # There exists a case where retrying a new upload will result in the
+            # API returning the POSTed payload (in bytes) with a non-200 response
+            # code.
+            #
+            # Retrying (after seeking back to 0) seems to resolve this problem.
+            raise F5ModuleError(
+                "Failed to upload file too many times."
+            )
+        try:
+            file_slice = fileobj.read(chunk_size)
+            if not file_slice:
+                break
+
+            current_bytes = len(file_slice)
+            if current_bytes < chunk_size:
+                end = size
+            else:
+                end = start + current_bytes
+            headers = {
+                'Content-Range': '%s-%s/%s' % (start, end - 1, size),
+                'Content-Type': 'application/octet-stream'
+            }
+
+            # Data should always be sent using the ``data`` keyword and not the
+            # ``json`` keyword. This allows bytes to be sent (such as in the case
+            # of uploading ISO files.
+            response = client.api.post(url, headers=headers, data=file_slice)
+
+            if response.status != 200:
+                # When this fails, the output is usually the body of whatever you
+                # POSTed. This is almost always unreadable because it is a series
+                # of bytes.
+                #
+                # Therefore, including an empty exception here.
+                raise F5ModuleError()
+            start += current_bytes
+        except F5ModuleError:
+            # You must seek back to the beginning of the file upon exception.
+            #
+            # If this is not done, then you risk uploading a partial file.
+            fileobj.seek(0)
+            retries += 1
+    return True
+
+
+def tmos_version(client):
+    uri = "https://{0}:{1}/mgmt/tm/sys/".format(
+        client.provider['server'],
+        client.provider['server_port'],
+    )
+    resp = client.api.get(uri)
+
+    try:
+        response = resp.json()
+    except ValueError as ex:
+        raise F5ModuleError(str(ex))
+
+    if 'code' in response and response['code'] in [400, 403]:
+        if 'message' in response:
+            raise F5ModuleError(response['message'])
+        else:
+            raise F5ModuleError(resp.content)
+
+    to_parse = urlparse(response['selfLink'])
+    query = to_parse.query
+    version = query.split('=')[1]
+    return version
+
+
+def bigiq_version(client):
+    uri = "https://{0}:{1}/mgmt/shared/resolver/device-groups/cm-shared-all-big-iqs/devices".format(
+        client.provider['server'],
+        client.provider['server_port'],
+    )
+    query = "?$select=version"
+
+    resp = client.api.get(uri + query)
+
+    try:
+        response = resp.json()
+    except ValueError as ex:
+        raise F5ModuleError(str(ex))
+
+    if 'code' in response and response['code'] in [400, 403]:
+        if 'message' in response:
+            raise F5ModuleError(response['message'])
+        else:
+            raise F5ModuleError(resp.content)
+
+    if 'items' in response:
+        version = response['items'][0]['version']
+        return version
+
+    raise F5ModuleError(
+        'Failed to retrieve BIGIQ version information.'
+    )
+
+
+def module_provisioned(client, module_name):
+    provisioned = modules_provisioned(client)
+    if module_name in provisioned:
+        return True
+    return False
+
+
+def modules_provisioned(client):
+    """Returns a list of all provisioned modules
+
+    Args:
+        client: Client connection to the BIG-IP
+
+    Returns:
+        A list of provisioned modules in their short name for.
+        For example, ['afm', 'asm', 'ltm']
+    """
+    uri = "https://{0}:{1}/mgmt/tm/sys/provision".format(
+        client.provider['server'],
+        client.provider['server_port']
+    )
+    resp = client.api.get(uri)
+
+    try:
+        response = resp.json()
+    except ValueError as ex:
+        raise F5ModuleError(str(ex))
+
+    if 'code' in response and response['code'] in [400, 403]:
+        if 'message' in response:
+            raise F5ModuleError(response['message'])
+        else:
+            raise F5ModuleError(resp.content)
+    if 'items' not in response:
+        return []
+    return [x['name'] for x in response['items'] if x['level'] != 'none']

--- a/plugins/module_utils/network/f5/_icontrol.py
+++ b/plugins/module_utils/network/f5/_icontrol.py
@@ -31,7 +31,7 @@ except ImportError:
 try:
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
 
 
 """An F5 REST API URI handler.
@@ -420,7 +420,7 @@ def upload_file(client, url, src, dest=None):
         file. BIG-IP has many different URLs that can be used to handle different
         types of files. This is why a full URL is required.
 
-        >>> from ansible_collections.community.network.plugins.module_utils.f5._icontrol import upload_client
+        >>> from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import upload_client
         >>> url = 'https://{0}:{1}/mgmt/cm/autodeploy/software-image-uploads'.format(
         ...   self.client.provider['server'],
         ...   self.client.provider['server_port']

--- a/plugins/module_utils/network/f5/_ipaddress.py
+++ b/plugins/module_utils/network/f5/_ipaddress.py
@@ -6,11 +6,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible.module_utils.network.common.utils import validate_ip_address
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import validate_ip_address
 
 try:
     # Ansible 2.6 and later
-    from ansible.module_utils.network.common.utils import validate_ip_v6_address
+    from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import validate_ip_v6_address
 except ImportError:
     import socket
 

--- a/plugins/module_utils/network/f5/_ipaddress.py
+++ b/plugins/module_utils/network/f5/_ipaddress.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.network.common.utils import validate_ip_address
+
+try:
+    # Ansible 2.6 and later
+    from ansible.module_utils.network.common.utils import validate_ip_v6_address
+except ImportError:
+    import socket
+
+    # Ansible 2.5 and earlier
+    #
+    # This method is simply backported from the 2.6 source code.
+    def validate_ip_v6_address(address):
+        try:
+            socket.inet_pton(socket.AF_INET6, address)
+        except socket.error:
+            return False
+        return True
+
+
+try:
+    from library.module_utils.compat.ipaddress import ip_interface
+    from library.module_utils.compat.ipaddress import ip_network
+except ImportError:
+    from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_interface
+    from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_network
+
+
+def is_valid_ip(addr, type='all'):
+    if type in ['all', 'ipv4']:
+        if validate_ip_address(addr):
+            return True
+    if type in ['all', 'ipv6']:
+        if validate_ip_v6_address(addr):
+            return True
+    return False
+
+
+def ipv6_netmask_to_cidr(mask):
+    """converts an IPv6 netmask to CIDR form
+
+    According to the link below, CIDR is the only official way to specify
+    a subset of IPv6. With that said, the same link provides a way to
+    loosely convert an netmask to a CIDR.
+
+    Arguments:
+      mask (string): The IPv6 netmask to convert to CIDR
+
+    Returns:
+      int: The CIDR representation of the netmask
+
+    References:
+      https://stackoverflow.com/a/33533007
+      http://v6decode.com/
+    """
+    bit_masks = [
+        0, 0x8000, 0xc000, 0xe000, 0xf000, 0xf800,
+        0xfc00, 0xfe00, 0xff00, 0xff80, 0xffc0,
+        0xffe0, 0xfff0, 0xfff8, 0xfffc, 0xfffe,
+        0xffff
+    ]
+    count = 0
+    try:
+        for w in mask.split(':'):
+            if not w or int(w, 16) == 0:
+                break
+            count += bit_masks.index(int(w, 16))
+        return count
+    except Exception:
+        return -1
+
+
+def is_valid_ip_network(address):
+    try:
+        ip_network(u'{0}'.format(address))
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_ip_interface(address):
+    try:
+        ip_interface(u'{0}'.format(address))
+        return True
+    except ValueError:
+        return False
+
+
+def get_netmask(address):
+    addr = ip_network(u'{0}'.format(address))
+    netmask = addr.netmask.compressed
+    return netmask
+
+
+def compress_address(address):
+    addr = ip_network(u'{0}'.format(address))
+    result = addr.compressed.split('/')[0]
+    return result

--- a/plugins/module_utils/network/f5/iworkflow.py
+++ b/plugins/module_utils/network/f5/iworkflow.py
@@ -20,8 +20,8 @@ try:
     from library.module_utils.network.f5.common import F5BaseClient
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5BaseClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
 
 
 class F5Client(F5BaseClient):

--- a/plugins/module_utils/network/f5/iworkflow.py
+++ b/plugins/module_utils/network/f5/iworkflow.py
@@ -20,8 +20,8 @@ try:
     from library.module_utils.network.f5.common import F5BaseClient
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
 
 
 class F5Client(F5BaseClient):

--- a/plugins/module_utils/network/f5/urls.py
+++ b/plugins/module_utils/network/f5/urls.py
@@ -12,7 +12,7 @@ import re
 try:
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
 
 _CLEAN_HEADER_REGEX_BYTE = re.compile(b'^\\S[^\\r\\n]*$|^$')
 _CLEAN_HEADER_REGEX_STR = re.compile(r'^\S[^\r\n]*$|^$')

--- a/plugins/module_utils/network/f5/urls.py
+++ b/plugins/module_utils/network/f5/urls.py
@@ -12,7 +12,7 @@ import re
 try:
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
 
 _CLEAN_HEADER_REGEX_BYTE = re.compile(b'^\\S[^\\r\\n]*$|^$')
 _CLEAN_HEADER_REGEX_STR = re.compile(r'^\S[^\r\n]*$|^$')

--- a/plugins/modules/network/f5/bigip_asm_policy.py
+++ b/plugins/modules/network/f5/bigip_asm_policy.py
@@ -248,14 +248,14 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import upload_file
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import tmos_version
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import module_provisioned
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import upload_file
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import tmos_version
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_asm_policy.py
+++ b/plugins/modules/network/f5/bigip_asm_policy.py
@@ -104,7 +104,7 @@ options:
       - Device partition to manage resources on.
     default: Common
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Wojciech Wypior (@wojtek0806)
@@ -248,14 +248,14 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import upload_file
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import tmos_version
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import module_provisioned
+    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import upload_file
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import tmos_version
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_device_info.py
+++ b/plugins/modules/network/f5/bigip_device_info.py
@@ -7004,16 +7004,16 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.urls import parseStats
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import flatten_boolean
-    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
-    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import modules_provisioned
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import tmos_version
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import flatten_boolean
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._ipaddress import is_valid_ip
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import modules_provisioned
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import tmos_version
     from ansible_collections.community.network.plugins.module_utils.network.f5.urls import parseStats
 
 

--- a/plugins/modules/network/f5/bigip_device_info.py
+++ b/plugins/modules/network/f5/bigip_device_info.py
@@ -160,7 +160,7 @@ options:
       - "!vlans"
     aliases: ['include']
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Tim Rupp (@caphrim007)
@@ -7004,16 +7004,16 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.urls import parseStats
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import flatten_boolean
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import modules_provisioned
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import tmos_version
+    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import flatten_boolean
+    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import modules_provisioned
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import tmos_version
     from ansible_collections.community.network.plugins.module_utils.network.f5.urls import parseStats
 
 

--- a/plugins/modules/network/f5/bigip_device_traffic_group.py
+++ b/plugins/modules/network/f5/bigip_device_traffic_group.py
@@ -90,7 +90,7 @@ options:
       - absent
     default: present
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Tim Rupp (@caphrim007)
@@ -203,13 +203,13 @@ try:
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import flatten_boolean
+    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import flatten_boolean
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_device_traffic_group.py
+++ b/plugins/modules/network/f5/bigip_device_traffic_group.py
@@ -203,13 +203,13 @@ try:
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import flatten_boolean
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import flatten_boolean
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_facts.py
+++ b/plugins/modules/network/f5/bigip_facts.py
@@ -74,7 +74,7 @@ options:
       - Shell-style glob matching string used to filter fact keys. Not
         applicable for software, provision, and system_info fact categories.
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 '''
 
@@ -104,8 +104,8 @@ try:
     from library.module_utils.network.f5.common import F5BaseClient
 except ImportError:
     from ansible_collections.community.network.plugins.module_utils.network.f5.legacy import bigip_api, bigsuds_found
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
 
 try:
     from suds import MethodNotFound, WebFault

--- a/plugins/modules/network/f5/bigip_facts.py
+++ b/plugins/modules/network/f5/bigip_facts.py
@@ -104,8 +104,8 @@ try:
     from library.module_utils.network.f5.common import F5BaseClient
 except ImportError:
     from ansible_collections.community.network.plugins.module_utils.network.f5.legacy import bigip_api, bigsuds_found
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5BaseClient
 
 try:
     from suds import MethodNotFound, WebFault

--- a/plugins/modules/network/f5/bigip_firewall_address_list.py
+++ b/plugins/modules/network/f5/bigip_firewall_address_list.py
@@ -96,7 +96,7 @@ options:
       - absent
     default: present
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Tim Rupp (@caphrim007)
@@ -178,16 +178,16 @@ try:
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.ipaddress import is_valid_ip_interface
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
     from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_address
     from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_interface
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip_interface
+    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip
+    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip_interface
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_firewall_address_list.py
+++ b/plugins/modules/network/f5/bigip_firewall_address_list.py
@@ -178,16 +178,16 @@ try:
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.ipaddress import is_valid_ip_interface
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import transform_name
     from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_address
     from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_interface
-    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip
-    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip_interface
+    from ansible_collections.community.network.plugins.module_utils.network.f5._ipaddress import is_valid_ip
+    from ansible_collections.community.network.plugins.module_utils.network.f5._ipaddress import is_valid_ip_interface
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_firewall_port_list.py
+++ b/plugins/modules/network/f5/bigip_firewall_port_list.py
@@ -185,13 +185,13 @@ try:
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import module_provisioned
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_firewall_port_list.py
+++ b/plugins/modules/network/f5/bigip_firewall_port_list.py
@@ -62,7 +62,7 @@ options:
       - absent
     default: present
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Tim Rupp (@caphrim007)
@@ -185,13 +185,13 @@ try:
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import module_provisioned
+    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_gtm_facts.py
+++ b/plugins/modules/network/f5/bigip_gtm_facts.py
@@ -40,7 +40,7 @@ deprecated:
     in the bigip_device_info module. Additionally, the M(bigip_device_info)
     module is easier to maintain and use.
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 notes:
   - This module is deprecated. Use the C(bigip_device_info) module instead.
@@ -194,16 +194,16 @@ except ImportError:
 try:
     from library.module_utils.network.f5.common import F5BaseClient
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
 
 try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
 
 
 class F5Client(F5BaseClient):

--- a/plugins/modules/network/f5/bigip_gtm_facts.py
+++ b/plugins/modules/network/f5/bigip_gtm_facts.py
@@ -194,16 +194,16 @@ except ImportError:
 try:
     from library.module_utils.network.f5.common import F5BaseClient
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5BaseClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5BaseClient
 
 try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
 
 
 class F5Client(F5BaseClient):

--- a/plugins/modules/network/f5/bigip_lx_package.py
+++ b/plugins/modules/network/f5/bigip_lx_package.py
@@ -49,7 +49,7 @@ requirements:
   - Requires BIG-IP >= 12.1.0
   - The 'rpm' tool installed on the Ansible controller
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Tim Rupp (@caphrim007)
@@ -105,12 +105,12 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import upload_file
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import tmos_version
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import upload_file
+    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import tmos_version
+    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import upload_file
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_lx_package.py
+++ b/plugins/modules/network/f5/bigip_lx_package.py
@@ -105,12 +105,12 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import upload_file
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigip import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import tmos_version
-    from ansible_collections.community.network.plugins.module_utils.f5._icontrol import upload_file
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigip import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import tmos_version
+    from ansible_collections.community.network.plugins.module_utils.network.f5._icontrol import upload_file
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigiq_device_info.py
+++ b/plugins/modules/network/f5/bigiq_device_info.py
@@ -836,14 +836,14 @@ try:
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
-    from ansible_collections.community.network.plugins.module_utils.f5._bigiq import F5RestClient
-    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
-    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
-    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
-    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
-    from ansible_collections.community.network.plugins.module_utils.f5._common import flatten_boolean
-    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip
-    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._bigiq import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import flatten_boolean
+    from ansible_collections.community.network.plugins.module_utils.network.f5._ipaddress import is_valid_ip
+    from ansible_collections.community.network.plugins.module_utils.network.f5._common import transform_name
 
 
 def parseStats(entry):

--- a/plugins/modules/network/f5/bigiq_device_info.py
+++ b/plugins/modules/network/f5/bigiq_device_info.py
@@ -44,7 +44,7 @@ options:
       - "!system-info"
       - "!vlans"
 extends_documentation_fragment:
-- f5networks.f5_modules.f5
+- community.network._f5
 
 author:
   - Tim Rupp (@caphrim007)
@@ -836,14 +836,14 @@ try:
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigiq import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import flatten_boolean
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
+    from ansible_collections.community.network.plugins.module_utils.f5._bigiq import F5RestClient
+    from ansible_collections.community.network.plugins.module_utils.f5._common import F5ModuleError
+    from ansible_collections.community.network.plugins.module_utils.f5._common import AnsibleF5Parameters
+    from ansible_collections.community.network.plugins.module_utils.f5._common import f5_argument_spec
+    from ansible_collections.community.network.plugins.module_utils.f5._common import fq_name
+    from ansible_collections.community.network.plugins.module_utils.f5._common import flatten_boolean
+    from ansible_collections.community.network.plugins.module_utils.f5._ipaddress import is_valid_ip
+    from ansible_collections.community.network.plugins.module_utils.f5._common import transform_name
 
 
 def parseStats(entry):

--- a/tests/unit/plugins/modules/network/f5/test_bigip_gtm_facts.py
+++ b/tests/unit/plugins/modules/network/f5/test_bigip_gtm_facts.py
@@ -38,6 +38,9 @@ except ImportError:
         from ansible_collections.f5networks.f5_modules.plugins.modules.network.f5.bigip_gtm_pool import PoolFactManager
         from ansible_collections.f5networks.f5_modules.plugins.modules.network.f5.bigip_gtm_pool import TypedPoolFactManager
         from ansible_collections.f5networks.f5_modules.plugins.modules.network.f5.bigip_gtm_pool import ArgumentSpec
+    except ImportError:
+        pytestmark.append(pytest.mark.skip("F5 bigip_gtm_facts test requires bigip_gtm_pool module from f5networks.f5_modules"))
+    try:
         from f5.bigip.tm.gtm.pool import A
         from f5.utils.responses.handlers import Stats
         from ansible_collections.community.network.tests.unit.plugins.modules.utils import set_module_args

--- a/tests/unit/plugins/modules/network/f5/test_bigip_security_address_list.py
+++ b/tests/unit/plugins/modules/network/f5/test_bigip_security_address_list.py
@@ -108,9 +108,11 @@ class TestManager(unittest.TestCase):
                 dict(country='EU')
             ],
             fqdns=['google.com', 'mit.edu'],
-            password='password',
-            server='localhost',
-            user='admin'
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
         ))
 
         module = AnsibleModule(

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,4 @@
+# requirements for F5 specific modules
+f5-sdk ; python_version >= '2.7'
+f5-icontrol-rest ; python_version >= '2.7'
+deepdiff


### PR DESCRIPTION
##### SUMMARY
As long as F5's collection isn't Ansible 2.10 ready, this collection will never fully work. This PR includes the required files from ansible/ansible's `pre-ansible-base`, marked as deprecated with a leading underscore, and drops the dependency on f5networks.f5_modules. This can be reverted when f5networks.f5_modules finally works with Ansible 2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
F5 plugins
