### PR TITLE
Remove version_added from return values and docs fragments

### DIFF
--- a/plugins/doc_fragments/_f5.py
+++ b/plugins/doc_fragments/_f5.py
@@ -14,7 +14,6 @@ options:
     description:
       - A dict object containing connection details.
     type: dict
-    version_added: '2.5'
     suboptions:
       password:
         description:

--- a/plugins/doc_fragments/panos.py
+++ b/plugins/doc_fragments/panos.py
@@ -31,7 +31,6 @@ options:
     provider:
         description:
             - A dict object containing connection details.
-        version_added: '2.8'
         required: true
         suboptions:
             ip_address:
@@ -73,7 +72,6 @@ options:
     provider:
         description:
             - A dict object containing connection details.
-        version_added: '2.8'
         suboptions:
             ip_address:
                 description:

--- a/plugins/modules/network/panos/panos_commit.py
+++ b/plugins/modules/network/panos/panos_commit.py
@@ -94,7 +94,6 @@ panos_commit:
     description: Information about commit job.
     returned: always
     type: complex
-    version_added: 2.8
     contains:
         job_id:
             description: Palo Alto job ID for the commit operation. Only returned if commit job is launched on device.


### PR DESCRIPTION
##### SUMMARY
These were left during migration, as opposed to `version_added` for options and plugins themselves.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules
