### PR TITLE
Update cnos.py

### DIFF
--- a/changelogs/fragments/terminal_plugin_cnos_update.yml
+++ b/changelogs/fragments/terminal_plugin_cnos_update.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Prevent timeout connection failure by adding "no logging terminal" after log in, in terminal plugin for cnos.
+  - cnos terminal plugin - prevent timeout connection failure by adding "no logging terminal" after log in (https://github.com/ansible-collections/community.network/pull/16).

--- a/changelogs/fragments/terminal_plugin_cnos_update.yml
+++ b/changelogs/fragments/terminal_plugin_cnos_update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Prevent timeout connection failure by adding "no logging terminal" after log in, in terminal plugin for cnos.

--- a/plugins/terminal/cnos.py
+++ b/plugins/terminal/cnos.py
@@ -44,7 +44,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'\n', b'terminal length 0\n'):
+            for cmd in (b'\n', b'terminal length 0\n',\
+                        b'no logging terminal\n'):
                 self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/plugins/terminal/cnos.py
+++ b/plugins/terminal/cnos.py
@@ -44,7 +44,7 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'\n', b'terminal length 0\n',\
+            for cmd in (b'\n', b'terminal length 0\n',
                         b'no logging terminal\n'):
                 self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:


### PR DESCRIPTION
Added "no logging terminal"  after log in.

##### SUMMARY
The problem was that, when trying to do a configuration on a Lenovo switch, in some cases, a timeout would occur with the following trace:

020-03-12 10:37:26,564 p=5491 u=root n=ansible | Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/ansible/utils/jsonrpc.py", line 45, in handle_request
    result = rpc_method(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/cliconf/__init__.py", line 42, in wrapped
    return func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/cliconf/cnos.py", line 102, in edit_config
    results.append(self.send_command(**line))
  File "/usr/lib/python2.7/site-packages/ansible/plugins/cliconf/__init__.py", line 127, in send_command
    resp = self._connection.send(**kwargs)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/__init__.py", line 35, in wrapped
    return func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/network_cli.py", line 580, in send
    response = self.receive(command, prompt, answer, newline, prompt_retry_check, check_all)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/network_cli.py", line 529, in receive
    data = self._ssh_shell.recv(256)
  File "/usr/lib/python2.7/site-packages/paramiko/channel.py", line 665, in recv
    out = self.in_buffer.read(nbytes, self.timeout)
  File "/usr/lib/python2.7/site-packages/paramiko/buffered_pipe.py", line 156, in read
    self._cv.wait(timeout)
  File "/usr/lib64/python2.7/threading.py", line 362, in wait
    _sleep(delay)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/network_cli.py", line 596, in _handle_command_timeout
    raise AnsibleConnectionFailure(msg)

After investigating, found out that the timeout occurred because some logs appear in the ssh terminal session in some cases, and the function that waits for the prompt, does not recognize the prompt in the response message, unless it is found at the end of the response. But in this case, the prompt is mixed up with the log message text. (This happens, for example, when trying to raise an interface (no shut command on an interface). When this command is issued, a log message immediately appears, showing the new state of the interface.)
And because of this timeout message, a chain reaction would occur and the switch could no longer be configured (timeout => switch stuck in the current submenu, and when trying to issue other cli commands, errors appear due to incorrect prompt).

The solution is to disable logging when ansible connects to the switch. This does not affect other connections in any way because the command takes effect only for the current session. Also, you would not be able to see those log messages anyway since there is no way to access that ansible ssh session, rendering them unnecessary.

 ##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/terminal/cnos.py

##### ADDITIONAL INFORMATION
Tested with the changes I propose and the timeout does not occur anymore. The switch configuration can be completely executed.
