### PR TITLE
Remove cisco.intersight dependency (which we don't need at all)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,6 @@ dependencies:
   ansible.netcommon: '>=0.1.0'
   cisco.mso: '>=0.1.0'
   cisco.aci: '>=0.1.0'
-  cisco.intersight: '>=0.1.0'
   check_point.mgmt: '>=0.1.0'
   fortinet.fortios: '>=0.1.0'
 #  f5networks.f5_modules: '>=0.1.0'

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -57,8 +57,6 @@ cd "${TEST_DIR}"
 # STAR: HACK install dependencies
 retry ansible-galaxy -vvv collection install ansible.netcommon
 retry ansible-galaxy -vvv collection install cisco.mso
-# https://github.com/CiscoDevNet/ansible-intersight/issues/9
-retry ansible-galaxy -vvv collection install cisco.intersight:1.0.4
 retry ansible-galaxy -vvv collection install check_point.mgmt
 retry ansible-galaxy -vvv collection install f5networks.f5_modules
 retry ansible-galaxy -vvv collection install fortinet.fortios


### PR DESCRIPTION
##### SUMMARY
We only install it, but don't need it anywhere.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dependencies
