### PR TITLE
Fix module._name checks

### DIFF
--- a/plugins/modules/network/f5/bigip_device_info.py
+++ b/plugins/modules/network/f5/bigip_device_info.py
@@ -16252,7 +16252,7 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if module._name == 'bigip_device_facts':
+    if module._name in ('bigip_device_facts', 'community.network.bigip_device_facts'):
         module.deprecate("The 'bigip_device_facts' module has been renamed to 'bigip_device_info'", version='2.13')
 
     try:

--- a/plugins/modules/network/f5/bigiq_device_info.py
+++ b/plugins/modules/network/f5/bigiq_device_info.py
@@ -2299,7 +2299,7 @@ def main():
         argument_spec=spec.argument_spec,
         supports_check_mode=spec.supports_check_mode
     )
-    if module._name == 'bigiq_device_facts':
+    if module._name in ('bigiq_device_facts', 'community.network.bigiq_device_facts'):
         module.deprecate("The 'bigiq_device_facts' module has been renamed to 'bigiq_device_info'", version='2.13')
 
     try:


### PR DESCRIPTION
##### SUMMARY
In times of collections, `module._name` can also contain the `community.nework.` prefix.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bigip_device_info
bigiq_device_info
