### PR TITLE
routeros: Bug fix: Exception catching

### DIFF
--- a/changelogs/fragments/27-routeros-exception-catching
+++ b/changelogs/fragments/27-routeros-exception-catching
@@ -1,0 +1,2 @@
+bugfixes:
+  - Created a try/except block on the function get_capabilities of routeros.py

--- a/changelogs/fragments/27-routeros-exception-catching
+++ b/changelogs/fragments/27-routeros-exception-catching
@@ -1,2 +1,2 @@
 bugfixes:
-  - Created a try/except block on the function get_capabilities of routeros.py
+  - routeros module_utils - created a ``try``/``except`` block on the function ``get_capabilities`` (https://github.com/ansible-collections/community.network/pull/27).

--- a/plugins/module_utils/network/routeros/routeros.py
+++ b/plugins/module_utils/network/routeros/routeros.py
@@ -26,7 +26,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import json
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.basic import env_fallback
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list, ComplexList
 from ansible.module_utils.connection import Connection, ConnectionError
@@ -71,7 +71,7 @@ def get_capabilities(module):
         module._routeros_capabilities = json.loads(capabilities)
         return module._routeros_capabilities
     except ConnectionError as exc:
-        module.fail_json(msg=to_text(exc))
+        module.fail_json(msg=to_native(exc, errors='surrogate_then_replace'))
 
 
 def get_defaults_flag(module):

--- a/plugins/module_utils/network/routeros/routeros.py
+++ b/plugins/module_utils/network/routeros/routeros.py
@@ -74,7 +74,6 @@ def get_capabilities(module):
         module.fail_json(msg=to_text(exc))
 
 
-
 def get_defaults_flag(module):
     connection = get_connection(module)
 

--- a/plugins/module_utils/network/routeros/routeros.py
+++ b/plugins/module_utils/network/routeros/routeros.py
@@ -66,9 +66,13 @@ def get_capabilities(module):
     if hasattr(module, '_routeros_capabilities'):
         return module._routeros_capabilities
 
-    capabilities = Connection(module._socket_path).get_capabilities()
-    module._routeros_capabilities = json.loads(capabilities)
-    return module._routeros_capabilities
+    try:
+        capabilities = Connection(module._socket_path).get_capabilities()
+        module._routeros_capabilities = json.loads(capabilities)
+        return module._routeros_capabilities
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc))
+
 
 
 def get_defaults_flag(module):


### PR DESCRIPTION
##### SUMMARY

The function get_capabilities was failing to catch connections exceptions, what make an ugly output


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
routeros.py

##### ADDITIONAL INFORMATION

 This error can be reproduced simply by providing an invalid username/password 

### OUTPUT BEFORE CHANGES:
```

The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-local-20843l7aphwz5/ansible-tmp-1588555470.4121525-264386939405924/AnsiballZ_routeros_comle>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-local-20843l7aphwz5/ansible-tmp-1588555470.4121525-264386939405924/AnsiballZ_routeros_comallz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-local-20843l7aphwz5/ansible-tmp-1588555470.4121525-264386939405924/AnsiballZ_routeros_com_module
    runpy.run_module(mod_name='ansible.modules.network.routeros.routeros_command', init_globals=None, run_name='__main__', a
  File "/usr/lib64/python2.7/runpy.py", line 176, in run_module
    fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 82, in _run_module_code
    mod_name, mod_fname, mod_loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/modules/network/routeros/r7, in <module>
  File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/modules/network/routeros/r7, in main
  File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/network/routein run_commands
  File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/network/routen get_connection
  File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/network/routen get_capabilities
  File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/connection.py
ansible.module_utils.connection.ConnectionError: Failed to authenticate: Authentication failed.
fatal: [MK]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/root/.ansible/tmp/ansible-local-20843l7aphwz5/ansible-tmp-1588555470.4121525-264386939405924/AnsiballZ_routerosmodule>
        _ansiballz_main()
      File "/root/.ansible/tmp/ansible-local-20843l7aphwz5/ansible-tmp-1588555470.4121525-264386939405924/AnsiballZ_routerosnsiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/root/.ansible/tmp/ansible-local-20843l7aphwz5/ansible-tmp-1588555470.4121525-264386939405924/AnsiballZ_routerosvoke_module
        runpy.run_module(mod_name='ansible.modules.network.routeros.routeros_command', init_globals=None, run_name='__main__
      File "/usr/lib64/python2.7/runpy.py", line 176, in run_module
        fname, loader, pkg_name)
      File "/usr/lib64/python2.7/runpy.py", line 82, in _run_module_code
        mod_name, mod_fname, mod_loader, pkg_name)
      File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
        exec code in run_globals
      File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/modules/network/routere 187, in <module>
      File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/modules/network/routere 157, in main
      File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/network/r25, in run_commands
      File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/network/r5, in get_connection
      File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/network/r9, in get_capabilities
      File "/tmp/ansible_routeros_command_payload_XbsRY1/ansible_routeros_command_payload.zip/ansible/module_utils/connectio
    ansible.module_utils.connection.ConnectionError: Failed to authenticate: Authentication failed.
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1

```
### OUTPUT AFTER CHANGES 

```
fatal: [MK]: FAILED! => changed=false
  msg: 'Failed to authenticate: Authentication failed.'
```