### PR TITLE
Add Fedora 32 to CI; drop Fedora 30 which is soon EOL

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -31,8 +31,8 @@ matrix:
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
     - env: T=linux/centos8/1
-    - env: T=linux/fedora30/1
     - env: T=linux/fedora31/1
+    - env: T=linux/fedora32/1
     - env: T=linux/opensuse15py2/1
     - env: T=linux/opensuse15/1
     - env: T=linux/ubuntu1604/1


### PR DESCRIPTION
##### SUMMARY
Implements ansible-collections/overview#59. I opted to drop Fedora 30 from CI, testing is more on the unit side, and integration tests are less OS dependent.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
CI
