### PR TITLE
cloudengine: fix Python 3.9 error

### DIFF
--- a/changelogs/fragments/36-ce_is_is_interface-python-3.9.yml
+++ b/changelogs/fragments/36-ce_is_is_interface-python-3.9.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ce_is_is_interface - fix compile error for Python 3.9 (https://github.com/ansible-collections/community.network/pull/36)."

--- a/plugins/modules/network/cloudengine/ce_is_is_interface.py
+++ b/plugins/modules/network/cloudengine/ce_is_is_interface.py
@@ -430,7 +430,7 @@ def get_interface_type(interface):
     elif interface.upper().startswith('STACK-PORT'):
         return 'stack-port'
     elif interface.upper().startswith('NULL'):
-        return'null'
+        return 'null'
     else:
         return None
 


### PR DESCRIPTION
##### SUMMARY
Found due to new default docker image.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ce_is_is_interface
