### PR TITLE
Fix example formatting

### DIFF
--- a/plugins/modules/network/a10/a10_server.py
+++ b/plugins/modules/network/a10/a10_server.py
@@ -66,8 +66,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a new server
-- a10_server:
+- name: Create a new server
+  a10_server:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -79,7 +79,6 @@ EXAMPLES = '''
         protocol: tcp
       - port_num: 8443
         protocol: TCP
-
 '''
 
 RETURN = '''

--- a/plugins/modules/network/a10/a10_server_axapi3.py
+++ b/plugins/modules/network/a10/a10_server_axapi3.py
@@ -63,8 +63,8 @@ RETURN = '''
 '''
 
 EXAMPLES = '''
-# Create a new server
-- a10_server:
+- name: Create a new server
+  a10_server:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -80,8 +80,8 @@ EXAMPLES = '''
         action: enable
       - port-number: 8443
         protocol: TCP
-
 '''
+
 import json
 
 from ansible_collections.community.network.plugins.module_utils.network.a10.a10 import axapi_call_v3, a10_argument_spec, axapi_authenticate_v3, axapi_failure

--- a/plugins/modules/network/a10/a10_service_group.py
+++ b/plugins/modules/network/a10/a10_service_group.py
@@ -79,8 +79,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a new service-group
-- a10_service_group:
+- name: Create a new service-group
+  a10_service_group:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -96,7 +96,6 @@ EXAMPLES = '''
       - server: foo4.mydomain.com
         port: 8080
         status: disabled
-
 '''
 
 RETURN = '''

--- a/plugins/modules/network/a10/a10_virtual_server.py
+++ b/plugins/modules/network/a10/a10_virtual_server.py
@@ -66,8 +66,8 @@ options:
 
 
 EXAMPLES = '''
-# Create a new virtual server
-- a10_virtual_server:
+- name: Create a new virtual server
+  a10_virtual_server:
     host: a10.mydomain.com
     username: myadmin
     password: mypassword
@@ -84,7 +84,6 @@ EXAMPLES = '''
       - port: 8080
         protocol: http
         status: disabled
-
 '''
 
 RETURN = '''

--- a/plugins/modules/network/aci/aci_interface_policy_fc.py
+++ b/plugins/modules/network/aci/aci_interface_policy_fc.py
@@ -53,7 +53,8 @@ author:
 '''
 
 EXAMPLES = r'''
-- aci_interface_policy_fc:
+- name: Add Fibre Channel interface policy
+  aci_interface_policy_fc:
     host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'

--- a/plugins/modules/network/aci/aci_interface_policy_l2.py
+++ b/plugins/modules/network/aci/aci_interface_policy_l2.py
@@ -64,7 +64,8 @@ author:
 '''
 
 EXAMPLES = r'''
-- aci_interface_policy_l2:
+- name: Add a Layer 2 interface policy
+  aci_interface_policy_l2:
     host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'

--- a/plugins/modules/network/aci/aci_interface_policy_lldp.py
+++ b/plugins/modules/network/aci/aci_interface_policy_lldp.py
@@ -58,7 +58,8 @@ author:
 
 # FIXME: Add more, better examples
 EXAMPLES = r'''
-- aci_interface_policy_lldp:
+- name: Add a LLDP interface policy
+  aci_interface_policy_lldp:
     host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'

--- a/plugins/modules/network/aci/aci_interface_policy_mcp.py
+++ b/plugins/modules/network/aci/aci_interface_policy_mcp.py
@@ -53,7 +53,8 @@ author:
 
 # FIXME: Add more, better examples
 EXAMPLES = r'''
-- aci_interface_policy_mcp:
+- name: Add a MCP interface policy
+  aci_interface_policy_mcp:
     host: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'

--- a/plugins/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/plugins/modules/network/aci/aci_interface_policy_port_channel.py
@@ -101,7 +101,8 @@ author:
 '''
 
 EXAMPLES = r'''
-- aci_interface_policy_port_channel:
+- name: Add aport channel interface policy
+  aci_interface_policy_port_channel:
     host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'

--- a/plugins/modules/network/aci/aci_interface_policy_port_security.py
+++ b/plugins/modules/network/aci/aci_interface_policy_port_security.py
@@ -60,7 +60,8 @@ author:
 
 # FIXME: Add more, better examples
 EXAMPLES = r'''
-- aci_interface_policy_port_security:
+- name: Add port security interface policy
+  aci_interface_policy_port_security:
     host: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'

--- a/plugins/modules/network/aireos/aireos_command.py
+++ b/plugins/modules/network/aireos/aireos_command.py
@@ -67,22 +67,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show sysinfo on remote devices
+  - name: Run show sysinfo on remote devices
     aireos_command:
       commands: show sysinfo
 
-  - name: run show sysinfo and check to see if output contains Cisco Controller
+  - name: Run show sysinfo and check to see if output contains Cisco Controller
     aireos_command:
       commands: show sysinfo
       wait_for: result[0] contains 'Cisco Controller'
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     aireos_command:
       commands:
         - show sysinfo
         - show interface summary
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     aireos_command:
       commands:
         - show sysinfo

--- a/plugins/modules/network/aireos/aireos_config.py
+++ b/plugins/modules/network/aireos/aireos_config.py
@@ -151,16 +151,16 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure configuration
+- name: Configure configuration
   aireos_config:
     lines: sysname testDevice
 
-- name: diff the running-config against a provided config
+- name: Diff the running-config against a provided config
   aireos_config:
     diff_against: intended
     intended: "{{ lookup('file', 'master.cfg') }}"
 
-- name: load new acl into device
+- name: Load new acl into device
   aireos_config:
     lines:
       - acl create testACL
@@ -168,7 +168,7 @@ EXAMPLES = """
       - acl rule direction testACL 3 in
     before: acl delete testACL
 
-- name: configurable backup path
+- name: Configurable backup path
   aireos_config:
     backup: yes
     lines: sysname testDevice

--- a/plugins/modules/network/aruba/aruba_command.py
+++ b/plugins/modules/network/aruba/aruba_command.py
@@ -67,22 +67,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     aruba_command:
       commands: show version
 
-  - name: run show version and check to see if output contains Aruba
+  - name: Run show version and check to see if output contains Aruba
     aruba_command:
       commands: show version
       wait_for: result[0] contains Aruba
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     aruba_command:
       commands:
         - show version
         - show interfaces
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     aruba_command:
       commands:
         - show version

--- a/plugins/modules/network/aruba/aruba_config.py
+++ b/plugins/modules/network/aruba/aruba_config.py
@@ -171,23 +171,23 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure top level configuration
+- name: Configure top level configuration
   aruba_config:
     lines: hostname {{ inventory_hostname }}
 
-- name: diff the running-config against a provided config
+- name: Diff the running-config against a provided config
   aruba_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
-- name: configure interface settings
+- name: Configure interface settings
   aruba_config:
     lines:
       - description test interface
       - ip access-group 1 in
     parents: interface gigabitethernet 0/0/0
 
-- name: load new acl into device
+- name: Load new acl into device
   aruba_config:
     lines:
       - permit host 10.10.10.10
@@ -196,7 +196,7 @@ EXAMPLES = """
     before: no ip access-list standard 1
     match: exact
 
-- name: configurable backup path
+- name: Configurable backup path
   aruba_config:
     backup: yes
     lines: hostname {{ inventory_hostname }}

--- a/plugins/modules/network/avi/avi_user.py
+++ b/plugins/modules/network/avi/avi_user.py
@@ -103,7 +103,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-  - name: user creation
+  - name: User creation
     avi_user:
       controller: ""
       username: ""
@@ -121,7 +121,7 @@ EXAMPLES = '''
       is_superuser: true
       default_tenant_ref: "/api/tenant?name=admin"
 
-  - name: user creation
+  - name: User creation
     avi_user:
       controller: ""
       username: ""

--- a/plugins/modules/network/bigswitch/bcf_switch.py
+++ b/plugins/modules/network/bigswitch/bcf_switch.py
@@ -55,7 +55,7 @@ options:
 
 
 EXAMPLES = '''
-- name: bcf leaf switch
+- name: Bcf leaf switch
   bcf_switch:
     name: Rack1Leaf1
     fabric_role: leaf

--- a/plugins/modules/network/bigswitch/bigmon_chain.py
+++ b/plugins/modules/network/bigswitch/bigmon_chain.py
@@ -45,7 +45,7 @@ options:
 
 
 EXAMPLES = '''
-- name: bigmon inline service chain
+- name: Bigmon inline service chain
   bigmon_chain:
     name: MyChain
     controller: '{{ inventory_hostname }}'

--- a/plugins/modules/network/bigswitch/bigmon_policy.py
+++ b/plugins/modules/network/bigswitch/bigmon_policy.py
@@ -70,7 +70,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: policy to aggregate filter and deliver data center (DC) 1 traffic
+- name: Policy to aggregate filter and deliver data center (DC) 1 traffic
   bigmon_policy:
     name: policy1
     policy_description: DC 1 traffic policy

--- a/plugins/modules/network/check_point/cp_publish.py
+++ b/plugins/modules/network/check_point/cp_publish.py
@@ -40,7 +40,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-- name: publish
+- name: Publish
   cp_publish:
 """
 

--- a/plugins/modules/network/cloudengine/ce_bfd_global.py
+++ b/plugins/modules/network/cloudengine/ce_bfd_global.py
@@ -77,7 +77,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: bfd global module test
+- name: Bfd global module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_bfd_session.py
+++ b/plugins/modules/network/cloudengine/ce_bfd_session.py
@@ -84,7 +84,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: bfd session module test
+- name: Bfd session module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_bfd_view.py
+++ b/plugins/modules/network/cloudengine/ce_bfd_view.py
@@ -88,7 +88,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: bfd view module test
+- name: Bfd view module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_config.py
+++ b/plugins/modules/network/cloudengine/ce_config.py
@@ -197,7 +197,7 @@ EXAMPLES = """
       replace: block
       provider: "{{ cli }}"
 
-  - name: configurable backup path
+  - name: Configurable backup path
     ce_config:
       lines: sysname {{ inventory_hostname }}
       provider: "{{ cli }}"

--- a/plugins/modules/network/cloudengine/ce_eth_trunk.py
+++ b/plugins/modules/network/cloudengine/ce_eth_trunk.py
@@ -76,7 +76,7 @@ options:
         choices: ['present','absent']
 '''
 EXAMPLES = '''
-- name: eth_trunk module test
+- name: Eth_trunk module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_evpn_bgp.py
+++ b/plugins/modules/network/cloudengine/ce_evpn_bgp.py
@@ -69,7 +69,7 @@ options:
         choices: ['present','absent']
 '''
 EXAMPLES = '''
-- name: evpn bgp module test
+- name: Evpn bgp module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_evpn_global.py
+++ b/plugins/modules/network/cloudengine/ce_evpn_global.py
@@ -39,7 +39,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: evpn global module test
+- name: Evpn global module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_info_center_global.py
+++ b/plugins/modules/network/cloudengine/ce_info_center_global.py
@@ -128,7 +128,7 @@ options:
         choices: ['present','absent']
 '''
 EXAMPLES = '''
-- name: info center global module test
+- name: Info center global module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_interface.py
+++ b/plugins/modules/network/cloudengine/ce_interface.py
@@ -70,7 +70,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: interface module test
+- name: Interface module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_interface_ospf.py
+++ b/plugins/modules/network/cloudengine/ce_interface_ospf.py
@@ -90,7 +90,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: eth_trunk module test
+- name: Eth_trunk module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_ip_interface.py
+++ b/plugins/modules/network/cloudengine/ce_ip_interface.py
@@ -67,7 +67,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: ip_interface module test
+- name: Ip_interface module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_is_is_instance.py
+++ b/plugins/modules/network/cloudengine/ce_is_is_instance.py
@@ -47,7 +47,7 @@ EXAMPLES = r'''
       instance_id: 3
       state: absent
 
-  - name: check isis process
+  - name: Check isis process
     ce_is_is_instance:
       instance_id: 4294967296
       state: present
@@ -58,7 +58,7 @@ EXAMPLES = r'''
       vpn_name: vpn1
       state: present
 
-  - name: check vpn name
+  - name: Check vpn name
     ce_is_is_instance:
       instance_id: 22
       vpn_name: vpn1234567896321452212221556asdasdasdasdsadvdv

--- a/plugins/modules/network/cloudengine/ce_is_is_view.py
+++ b/plugins/modules/network/cloudengine/ce_is_is_view.py
@@ -266,13 +266,13 @@ EXAMPLES = '''
       stdlevel1cost: 63
       state: present
 
-  - name: set isis stdlevel2cost
+  - name: Set isis stdlevel2cost
     ce_is_is_view:
       instance_id: 3
       stdlevel2cost: 63
       state: present
 
-  - name: set isis stdbandwidth
+  - name: Set isis stdbandwidth
     ce_is_is_view:
       instance_id: 3
       stdbandwidth: 1

--- a/plugins/modules/network/cloudengine/ce_mlag_config.py
+++ b/plugins/modules/network/cloudengine/ce_mlag_config.py
@@ -71,7 +71,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: mlag config module test
+- name: Mlag config module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_mlag_interface.py
+++ b/plugins/modules/network/cloudengine/ce_mlag_interface.py
@@ -67,7 +67,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: mlag interface module test
+- name: Mlag interface module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_multicast_global.py
+++ b/plugins/modules/network/cloudengine/ce_multicast_global.py
@@ -41,17 +41,17 @@ options:
 
 EXAMPLES = '''
 ---
-  - name: multicast routing-enable
+  - name: Multicast routing-enable
     ce_multicast_global:
       aftype: v4
       state: absent
       provider: "{{ cli }}"
-  - name: multicast routing-enable
+  - name: Multicast routing-enable
     ce_multicast_global:
       aftype: v4
       state: present
       provider: "{{ cli }}"
-  - name: multicast routing-enable
+  - name: Multicast routing-enable
     ce_multicast_global:
       aftype: v4
       vrf: vrf1

--- a/plugins/modules/network/cloudengine/ce_multicast_igmp_enable.py
+++ b/plugins/modules/network/cloudengine/ce_multicast_igmp_enable.py
@@ -63,26 +63,26 @@ options:
 
 EXAMPLES = '''
 
-  - name: configure global igmp enable
+  - name: Configure global igmp enable
     ce_multicast_igmp_enable:
       aftype: v4
       features: 'global'
       state: present
 
-  - name: configure global igmp disable
+  - name: Configure global igmp disable
     ce_multicast_igmp_enable:
       features: 'global'
       aftype: v4
       state: absent
 
-  - name: configure vlan igmp enable
+  - name: Configure vlan igmp enable
     ce_multicast_igmp_enable:
       features: 'vlan'
       aftype: v4
       vlan_id: 1
       igmp: true
 
-  - name: new proxy,igmp,version
+  - name: New proxy,igmp,version
     ce_multicast_igmp_enable:
       features: 'vlan'
       aftype: v4
@@ -91,14 +91,14 @@ EXAMPLES = '''
       igmp: true
       version: 1
 
-  - name: modify proxy,igmp,version
+  - name: Modify proxy,igmp,version
     ce_multicast_igmp_enable:
       features: 'vlan'
       aftype: v4
       vlan_id: 1
       version: 2
 
-  - name: delete proxy,igmp,version
+  - name: Delete proxy,igmp,version
     ce_multicast_igmp_enable:
       features: 'vlan'
       aftype: v4

--- a/plugins/modules/network/cloudengine/ce_netstream_aging.py
+++ b/plugins/modules/network/cloudengine/ce_netstream_aging.py
@@ -54,7 +54,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: netstream aging module test
+- name: Netstream aging module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_netstream_export.py
+++ b/plugins/modules/network/cloudengine/ce_netstream_export.py
@@ -71,7 +71,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: netstream export module test
+- name: Netstream export module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_netstream_global.py
+++ b/plugins/modules/network/cloudengine/ce_netstream_global.py
@@ -65,7 +65,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: netstream global module test
+- name: Netstream global module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_netstream_template.py
+++ b/plugins/modules/network/cloudengine/ce_netstream_template.py
@@ -64,7 +64,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: netstream template module test
+- name: Netstream template module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_ospf.py
+++ b/plugins/modules/network/cloudengine/ce_ospf.py
@@ -86,7 +86,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: ospf module test
+- name: Ospf module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_ospf_vrf.py
+++ b/plugins/modules/network/cloudengine/ce_ospf_vrf.py
@@ -138,7 +138,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: ospf vrf module test
+- name: Ospf vrf module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_reboot.py
+++ b/plugins/modules/network/cloudengine/ce_reboot.py
@@ -46,7 +46,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: reboot module test
+- name: Reboot module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_rollback.py
+++ b/plugins/modules/network/cloudengine/ce_rollback.py
@@ -61,7 +61,7 @@ options:
         choices: ['rollback','clear','set','display','commit']
 '''
 EXAMPLES = '''
-- name: rollback module test
+- name: Rollback module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_sflow.py
+++ b/plugins/modules/network/cloudengine/ce_sflow.py
@@ -138,7 +138,7 @@ options:
 EXAMPLES = '''
 ---
 
-- name: sflow module test
+- name: Sflow module test
   hosts: ce128
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_startup.py
+++ b/plugins/modules/network/cloudengine/ce_startup.py
@@ -55,7 +55,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: startup module test
+- name: Startup module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_static_route.py
+++ b/plugins/modules/network/cloudengine/ce_static_route.py
@@ -61,7 +61,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: static route module test
+- name: Static route module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_static_route_bfd.py
+++ b/plugins/modules/network/cloudengine/ce_static_route_bfd.py
@@ -125,7 +125,7 @@ EXAMPLES = '''
       state: present
 
   #undo ip route-static bfd [ interface-type interface-number | vpn-instance vpn-instance-name ] nexthop-address
-  - name: undo ip route-static bfd 10GE1/0/1 3.3.3.4
+  - name: Undo ip route-static bfd 10GE1/0/1 3.3.3.4
     ce_static_route_bfd:
       function_flag: 'singleBFD'
       nhp_interface: 10GE1/0/1
@@ -143,7 +143,7 @@ EXAMPLES = '''
       aftype: v4
       state: present
 
-  - name: undo ip route-static default-bfd
+  - name: Undo ip route-static default-bfd
     ce_static_route_bfd:
       function_flag: 'globalBFD'
       aftype: v4

--- a/plugins/modules/network/cloudengine/ce_switchport.py
+++ b/plugins/modules/network/cloudengine/ce_switchport.py
@@ -70,7 +70,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: switchport module test
+- name: Switchport module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vlan.py
+++ b/plugins/modules/network/cloudengine/ce_vlan.py
@@ -51,7 +51,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vlan module test
+- name: Vlan module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vrf.py
+++ b/plugins/modules/network/cloudengine/ce_vrf.py
@@ -47,7 +47,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vrf module test
+- name: Vrf module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vrf_af.py
+++ b/plugins/modules/network/cloudengine/ce_vrf_af.py
@@ -70,7 +70,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vrf af module test
+- name: Vrf af module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vrrp.py
+++ b/plugins/modules/network/cloudengine/ce_vrrp.py
@@ -127,7 +127,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vrrp module test
+- name: Vrrp module test
   hosts: cloudengine
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vxlan_arp.py
+++ b/plugins/modules/network/cloudengine/ce_vxlan_arp.py
@@ -78,7 +78,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vxlan arp module test
+- name: Vxlan arp module test
   hosts: ce128
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vxlan_gateway.py
+++ b/plugins/modules/network/cloudengine/ce_vxlan_gateway.py
@@ -107,7 +107,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vxlan gateway module test
+- name: Vxlan gateway module test
   hosts: ce128
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vxlan_global.py
+++ b/plugins/modules/network/cloudengine/ce_vxlan_global.py
@@ -73,7 +73,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vxlan global module test
+- name: Vxlan global module test
   hosts: ce128
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vxlan_tunnel.py
+++ b/plugins/modules/network/cloudengine/ce_vxlan_tunnel.py
@@ -64,7 +64,7 @@ options:
         choices: ['present','absent']
 '''
 EXAMPLES = '''
-- name: vxlan tunnel module test
+- name: Vxlan tunnel module test
   hosts: ce128
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cloudengine/ce_vxlan_vap.py
+++ b/plugins/modules/network/cloudengine/ce_vxlan_vap.py
@@ -67,7 +67,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: vxlan vap module test
+- name: Vxlan vap module test
   hosts: ce128
   connection: local
   gather_facts: no

--- a/plugins/modules/network/cnos/cnos_banner.py
+++ b/plugins/modules/network/cnos/cnos_banner.py
@@ -124,7 +124,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure the login banner
+- name: Configure the login banner
   cnos_banner:
     banner: login
     text: |
@@ -133,7 +133,7 @@ EXAMPLES = """
       string
     state: present
 
-- name: remove the motd banner
+- name: Remove the motd banner
   cnos_banner:
     banner: motd
     state: absent

--- a/plugins/modules/network/cnos/cnos_command.py
+++ b/plugins/modules/network/cnos/cnos_command.py
@@ -74,7 +74,7 @@ options:
 
 EXAMPLES = """
 ---
-- name: test contains operator
+- name: Test contains operator
   cnos_command:
     commands:
       - show version
@@ -89,7 +89,7 @@ EXAMPLES = """
       - "result.changed == false"
       - "result.stdout is defined"
 
-- name: get output for single command
+- name: Get output for single command
   cnos_command:
     commands: ['show version']
   register: result
@@ -99,7 +99,7 @@ EXAMPLES = """
       - "result.changed == false"
       - "result.stdout is defined"
 
-- name: get output for multiple commands
+- name: Get output for multiple commands
   cnos_command:
     commands:
       - show version

--- a/plugins/modules/network/cnos/cnos_config.py
+++ b/plugins/modules/network/cnos/cnos_config.py
@@ -145,23 +145,23 @@ options:
 EXAMPLES = """
 Tasks: The following are examples of using the module cnos_config.
 ---
-- name: configure top level configuration
+- name: Configure top level configuration
   cnos_config:
     "lines: hostname {{ inventory_hostname }}"
 
-- name: configure interface settings
+- name: Configure interface settings
   cnos_config:
     lines:
       - enable
       - ip ospf enable
     parents: interface ip 13
 
-- name: load a config from disk and replace the current config
+- name: Load a config from disk and replace the current config
   cnos_config:
     src: config.cfg
     backup: yes
 
-- name: configurable backup path
+- name: Configurable backup path
   cnos_config:
     src: config.cfg
     backup: yes

--- a/plugins/modules/network/cnos/cnos_interface.py
+++ b/plugins/modules/network/cnos/cnos_interface.py
@@ -158,7 +158,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure interface
+- name: Configure interface
   cnos_interface:
       name: Ethernet1/33
       description: test-interface
@@ -166,17 +166,17 @@ EXAMPLES = """
       duplex: half
       mtu: 999
 
-- name: remove interface
+- name: Remove interface
   cnos_interface:
     name: loopback3
     state: absent
 
-- name: make interface up
+- name: Make interface up
   cnos_interface:
     name: Ethernet1/33
     enabled: True
 
-- name: make interface down
+- name: Make interface down
   cnos_interface:
     name: Ethernet1/33
     enabled: False

--- a/plugins/modules/network/cnos/cnos_linkagg.py
+++ b/plugins/modules/network/cnos/cnos_linkagg.py
@@ -118,17 +118,17 @@ options:
 '''
 
 EXAMPLES = """
-- name: create link aggregation group
+- name: Create link aggregation group
   cnos_linkagg:
     group: 10
     state: present
 
-- name: delete link aggregation group
+- name: Delete link aggregation group
   cnos_linkagg:
     group: 10
     state: absent
 
-- name: set link aggregation group to members
+- name: Set link aggregation group to members
   cnos_linkagg:
     group: 200
     mode: active
@@ -136,7 +136,7 @@ EXAMPLES = """
       - Ethernet1/33
       - Ethernet1/44
 
-- name: remove link aggregation group from GigabitEthernet0/0
+- name: Remove link aggregation group from GigabitEthernet0/0
   cnos_linkagg:
     group: 200
     mode: active

--- a/plugins/modules/network/cnos/cnos_logging.py
+++ b/plugins/modules/network/cnos/cnos_logging.py
@@ -66,26 +66,26 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure server logging
+- name: Configure server logging
   cnos_logging:
     dest: server
     name: 10.241.107.224
     facility: local7
     state: present
 
-- name: remove server logging configuration
+- name: Remove server logging configuration
   cnos_logging:
     dest: server
     name: 10.241.107.224
     state: absent
 
-- name: configure console logging level and facility
+- name: Configure console logging level and facility
   cnos_logging:
     dest: console
     level: 7
     state: present
 
-- name: configure buffer size
+- name: Configure buffer size
   cnos_logging:
     dest: logfile
     level: 5
@@ -98,7 +98,7 @@ EXAMPLES = """
       - { dest: console, level: 6 }
       - { dest: logfile, size: 9000 }
 
-- name: remove logging using aggregate
+- name: Remove logging using aggregate
   cnos_logging:
     aggregate:
       - { dest: console, level: 6 }

--- a/plugins/modules/network/cnos/cnos_static_route.py
+++ b/plugins/modules/network/cnos/cnos_static_route.py
@@ -67,13 +67,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure static route
+- name: Configure static route
   cnos_static_route:
     prefix: 10.241.107.0
     mask: 255.255.255.0
     next_hop: 10.241.106.1
 
-- name: configure ultimate route with name and tag
+- name: Configure ultimate route with name and tag
   cnos_static_route:
     prefix: 10.241.107.0
     mask: 255.255.255.0
@@ -81,7 +81,7 @@ EXAMPLES = """
     description: hello world
     tag: 100
 
-- name: remove configuration
+- name: Remove configuration
   cnos_static_route:
     prefix: 10.241.107.0
     mask: 255.255.255.0

--- a/plugins/modules/network/cnos/cnos_system.py
+++ b/plugins/modules/network/cnos/cnos_system.py
@@ -81,27 +81,27 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure hostname and domain-name
+- name: Configure hostname and domain-name
   cnos_system:
     hostname: cnos01
     domain_name: test.example.com
 
-- name: remove configuration
+- name: Remove configuration
   cnos_system:
     state: absent
 
-- name: configure name servers
+- name: Configure name servers
   cnos_system:
     name_servers:
       - 8.8.8.8
       - 8.8.4.4
 
-- name: configure DNS Lookup sources
+- name: Configure DNS Lookup sources
   cnos_system:
     lookup_source: MgmtEth0/0/CPU0/0
     lookup_enabled: yes
 
-- name: configure name servers with VRF support
+- name: Configure name servers with VRF support
   nxos_system:
     name_servers:
       - { server: 8.8.8.8, vrf: mgmt }

--- a/plugins/modules/network/cnos/cnos_user.py
+++ b/plugins/modules/network/cnos/cnos_user.py
@@ -93,20 +93,20 @@ options:
 '''
 
 EXAMPLES = """
-- name: create a new user
+- name: Create a new user
   cnos_user:
     name: ansible
     sshkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
     state: present
 
-- name: remove all users except admin
+- name: Remove all users except admin
   cnos_user:
     purge: yes
 
-- name: set multiple users role
+- name: Set multiple users role
   aggregate:
-    - name: netop
-    - name: netend
+    - name: Netop
+    - name: Netend
   role: network-operator
   state: present
 """

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -104,19 +104,19 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure the remote device
+- name: Configure the remote device
   edgeos_config:
     lines:
       - set system host-name {{ inventory_hostname }}
       - set service lldp
       - delete service dhcp-server
 
-- name: backup and load from file
+- name: Backup and load from file
   edgeos_config:
     src: edgeos.cfg
     backup: yes
 
-- name: configurable backup path
+- name: Configurable backup path
   edgeos_config:
     src: edgeos.cfg
     backup: yes

--- a/plugins/modules/network/edgeos/edgeos_facts.py
+++ b/plugins/modules/network/edgeos/edgeos_facts.py
@@ -36,15 +36,15 @@ options:
 '''
 
 EXAMPLES = """
-- name: collect all facts from the device
+- name: Collect all facts from the device
   edgeos_facts:
     gather_subset: all
 
-- name: collect only the config and default facts
+- name: Collect only the config and default facts
   edgeos_facts:
     gather_subset: config
 
-- name: collect everything exception the config
+- name: Collect everything exception the config
   edgeos_facts:
     gather_subset: "!config"
 """

--- a/plugins/modules/network/edgeswitch/edgeswitch_facts.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_facts.py
@@ -34,15 +34,14 @@ options:
 '''
 
 EXAMPLES = """
-# Collect all facts from the device
-- edgeswitch_facts:
+- name: Collect all facts from the device
+  edgeswitch_facts:
     gather_subset: all
 
-# Collect only the config and default facts
-- edgeswitch_facts:
+- name: Collect only the config and default facts
+  edgeswitch_facts:
     gather_subset:
       - config
-
 """
 
 RETURN = """

--- a/plugins/modules/network/edgeswitch/edgeswitch_vlan.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_vlan.py
@@ -88,7 +88,7 @@ EXAMPLES = """
       - 0/1
       - 0/4-0/6
 
-- name: setup three vlans and delete the rest
+- name: Setup three vlans and delete the rest
   edgeswitch_vlan:
     purge: true
     aggregate:

--- a/plugins/modules/network/enos/enos_command.py
+++ b/plugins/modules/network/enos/enos_command.py
@@ -88,7 +88,7 @@ vars:
     timeout: 30
 
 ---
-- name: test contains operator
+- name: Test contains operator
   enos_command:
     commands:
       - show version
@@ -104,7 +104,7 @@ vars:
       - "result.changed == false"
       - "result.stdout is defined"
 
-- name: get output for single command
+- name: Get output for single command
   enos_command:
     commands: ['show version']
     provider: "{{ cli }}"
@@ -115,7 +115,7 @@ vars:
       - "result.changed == false"
       - "result.stdout is defined"
 
-- name: get output for multiple commands
+- name: Get output for multiple commands
   enos_command:
     commands:
       - show version

--- a/plugins/modules/network/enos/enos_config.py
+++ b/plugins/modules/network/enos/enos_config.py
@@ -146,23 +146,23 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure top level configuration
+- name: Configure top level configuration
   enos_config:
     "lines: hostname {{ inventory_hostname }}"
 
-- name: configure interface settings
+- name: Configure interface settings
   enos_config:
     lines:
       - enable
       - ip ospf enable
     parents: interface ip 13
 
-- name: load a config from disk and replace the current config
+- name: Load a config from disk and replace the current config
   enos_config:
     src: config.cfg
     backup: yes
 
-- name: configurable backup path
+- name: Configurable backup path
   enos_config:
     src: config.cfg
     backup: yes

--- a/plugins/modules/network/eric_eccli/eric_eccli_command.py
+++ b/plugins/modules/network/eric_eccli/eric_eccli_command.py
@@ -79,22 +79,22 @@ notes:
 
 EXAMPLES = r"""
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     eric_eccli_command:
       commands: show version
 
-  - name: run show version and check to see if output contains IPOS
+  - name: Run show version and check to see if output contains IPOS
     eric_eccli_command:
       commands: show version
       wait_for: result[0] contains IPOS
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     eric_eccli_command:
       commands:
         - show version
         - show running-config interfaces
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     eric_eccli_command:
       commands:
         - show version

--- a/plugins/modules/network/exos/exos_command.py
+++ b/plugins/modules/network/exos/exos_command.py
@@ -65,19 +65,19 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     exos_command:
       commands: show version
-  - name: run show version and check to see if output contains ExtremeXOS
+  - name: Run show version and check to see if output contains ExtremeXOS
     exos_command:
       commands: show version
       wait_for: result[0] contains ExtremeXOS
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     exos_command:
       commands:
         - show version
         - show ports no-refresh
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     exos_command:
       commands:
         - show version
@@ -85,7 +85,7 @@ tasks:
       wait_for:
         - result[0] contains ExtremeXOS
         - result[1] contains 20
-  - name: run command that requires answering a prompt
+  - name: Run command that requires answering a prompt
     exos_command:
       commands:
         - command: 'clear license-info'

--- a/plugins/modules/network/exos/exos_config.py
+++ b/plugins/modules/network/exos/exos_config.py
@@ -161,32 +161,32 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure SNMP system name
+- name: Configure SNMP system name
   exos_config:
     lines: configure snmp sysName "{{ inventory_hostname }}"
 
-- name: configure interface settings
+- name: Configure interface settings
   exos_config:
     lines:
       - configure ports 2 description-string "Master Uplink"
     backup: yes
 
-- name: check the running-config against master config
+- name: Check the running-config against master config
   exos_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
-- name: check the startup-config against the running-config
+- name: Check the startup-config against the running-config
   exos_config:
     diff_against: startup
     diff_ignore_lines:
       - ntp clock .*
 
-- name: save running to startup when modified
+- name: Save running to startup when modified
   exos_config:
     save_when: modified
 
-- name: configurable backup path
+- name: Configurable backup path
   exos_config:
     lines:
       - configure ports 2 description-string "Master Uplink"

--- a/plugins/modules/network/exos/exos_facts.py
+++ b/plugins/modules/network/exos/exos_facts.py
@@ -69,7 +69,7 @@ EXAMPLES = """
     exos_facts:
       gather_subset: config
 
-  - name: do not gather hardware facts
+  - name: Do not gather hardware facts
     exos_facts:
       gather_subset: "!hardware"
 

--- a/plugins/modules/network/icx/icx_banner.py
+++ b/plugins/modules/network/icx/icx_banner.py
@@ -54,7 +54,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure the motd banner
+- name: Configure the motd banner
   icx_banner:
     banner: motd
     text: |
@@ -63,17 +63,17 @@ EXAMPLES = """
         string
     state: present
 
-- name: remove the motd banner
+- name: Remove the motd banner
   icx_banner:
     banner: motd
     state: absent
 
-- name: configure require-enter-key for motd
+- name: Configure require-enter-key for motd
   icx_banner:
     banner: motd
     enterkey: True
 
-- name: remove require-enter-key for motd
+- name: Remove require-enter-key for motd
   icx_banner:
     banner: motd
     enterkey: False

--- a/plugins/modules/network/icx/icx_command.py
+++ b/plugins/modules/network/icx/icx_command.py
@@ -73,22 +73,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     icx_command:
       commands: show version
 
-  - name: run show version and check to see if output contains ICX
+  - name: Run show version and check to see if output contains ICX
     icx_command:
       commands: show version
       wait_for: result[0] contains ICX
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     icx_command:
       commands:
         - show version
         - show interfaces
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     icx_command:
       commands:
         - show version
@@ -96,13 +96,13 @@ tasks:
       wait_for:
         - result[0] contains ICX
         - result[1] contains GigabitEthernet1/1/1
-  - name: run commands that require answering a prompt
+  - name: Run commands that require answering a prompt
     icx_command:
       commands:
         - command: 'service password-encryption sha1'
           prompt: 'Warning: Moving to higher password-encryption type,.*'
           answer: 'y'
-  - name: run commands that require answering multiple prompt
+  - name: Run commands that require answering multiple prompt
     icx_command:
       commands:
         - command: 'username qqq password qqq'

--- a/plugins/modules/network/icx/icx_config.py
+++ b/plugins/modules/network/icx/icx_config.py
@@ -169,18 +169,18 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure top level configuration
+- name: Configure top level configuration
   icx_config:
     lines: hostname {{ inventory_hostname }}
 
-- name: configure interface settings
+- name: Configure interface settings
   icx_config:
     lines:
       - port-name test string
       - ip address 172.31.1.1 255.255.255.0
     parents: interface ethernet 1/1/2
 
-- name: configure ip helpers on multiple interfaces
+- name: Configure ip helpers on multiple interfaces
   icx_config:
     lines:
       - ip helper-address 172.26.1.10
@@ -190,7 +190,7 @@ EXAMPLES = """
     - interface ethernet 1/1/2
     - interface ethernet 1/1/3
 
-- name: load new acl into device
+- name: Load new acl into device
   icx_config:
     lines:
       - permit ip host 192.0.2.1 any log
@@ -201,18 +201,18 @@ EXAMPLES = """
     before: no ip access-list extended test
     match: exact
 
-- name: check the running-config against master config
+- name: Check the running-config against master config
   icx_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
-- name: check the configuration against the running-config
+- name: Check the configuration against the running-config
   icx_config:
     diff_against: startup
     diff_ignore_lines:
       - ntp clock .*
 
-- name: for idempotency, use full-form commands
+- name: For idempotency, use full-form commands
   icx_config:
     lines:
       # - en
@@ -230,7 +230,7 @@ EXAMPLES = """
     host: "{{ inventory_hostname }}"
   when: ansible_net_version != version
 
-- name: render template onto an ICX device
+- name: Render template onto an ICX device
   icx_config:
     backup: yes
     src: "{{ lookup('file', 'config.j2') }}"

--- a/plugins/modules/network/icx/icx_copy.py
+++ b/plugins/modules/network/icx/icx_copy.py
@@ -64,7 +64,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: upload running-config to the remote scp server
+- name: Upload running-config to the remote scp server
   icx_copy:
     upload: running-config
     protocol: scp
@@ -73,7 +73,7 @@ EXAMPLES = """
     remote_user: user1
     remote_pass: pass123
 
-- name: download running-config from the remote scp server
+- name: Download running-config from the remote scp server
   icx_copy:
     download: running-config
     protocol: scp
@@ -82,7 +82,7 @@ EXAMPLES = """
     remote_user: user1
     remote_pass: pass123
 
-- name: download running-config from the remote scp server using rsa public key
+- name: Download running-config from the remote scp server using rsa public key
   icx_copy:
     download: running-config
     protocol: scp
@@ -92,7 +92,7 @@ EXAMPLES = """
     remote_pass: pass123
     public_key: rsa
 
-- name: upload startup-config to the remote https server
+- name: Upload startup-config to the remote https server
   icx_copy:
     upload: startup-config
     protocol: https
@@ -101,7 +101,7 @@ EXAMPLES = """
     remote_user: user1
     remote_pass: pass123
 
-- name: upload startup-config to the remote https server
+- name: Upload startup-config to the remote https server
   icx_copy:
     upload: startup-config
     protocol: https

--- a/plugins/modules/network/icx/icx_facts.py
+++ b/plugins/modules/network/icx/icx_facts.py
@@ -34,17 +34,17 @@ options:
 '''
 
 EXAMPLES = """
-# Collect all facts from the device
-- icx_facts:
+- name: Collect all facts from the device
+  icx_facts:
     gather_subset: all
 
-# Collect only the config and default facts
-- icx_facts:
+- name: Collect only the config and default facts
+  icx_facts:
     gather_subset:
       - config
 
-# Do not collect hardware facts
-- icx_facts:
+- name: Do not collect hardware facts
+  icx_facts:
     gather_subset:
       - "!hardware"
 """

--- a/plugins/modules/network/icx/icx_interface.py
+++ b/plugins/modules/network/icx/icx_interface.py
@@ -216,44 +216,44 @@ options:
 '''
 
 EXAMPLES = """
-- name: enable ethernet port and set name
+- name: Enable ethernet port and set name
   icx_interface:
     name: ethernet 1/1/1
     description: interface-1
     stp: true
     enabled: true
 
-- name: disable ethernet port 1/1/1
+- name: Disable ethernet port 1/1/1
   icx_interface:
       name: ethernet 1/1/1
       enabled: false
 
-- name: enable ethernet port range, set name and speed.
+- name: Enable ethernet port range, set name and speed
   icx_interface:
       name: ethernet 1/1/1 to 1/1/10
       description: interface-1
       speed: 100-full
       enabled: true
 
-- name: enable poe. Set class.
+- name: Enable poe. Set class
   icx_interface:
       name: ethernet 1/1/1
       power:
        by_class: 2
 
-- name: configure poe limit of interface
+- name: Configure poe limit of interface
   icx_interface:
       name: ethernet 1/1/1
       power:
        limit: 10000
 
-- name: disable poe of interface
+- name: Disable poe of interface
   icx_interface:
       name: ethernet 1/1/1
       power:
        enabled: false
 
-- name: set lag name for a range of lags
+- name: Set lag name for a range of lags
   icx_interface:
       name: lag 1 to 10
       description: test lags
@@ -263,12 +263,12 @@ EXAMPLES = """
       name: lag 1
       enabled: false
 
-- name: enable management interface
+- name: Enable management interface
   icx_interface:
       name: management 1
       enabled: true
 
-- name: enable loopback interface
+- name: Enable loopback interface
   icx_interface:
       name: loopback 10
       enabled: true

--- a/plugins/modules/network/icx/icx_linkagg.py
+++ b/plugins/modules/network/icx/icx_linkagg.py
@@ -90,19 +90,19 @@ options:
 '''
 
 EXAMPLES = """
-- name: create static link aggregation group
+- name: Create static link aggregation group
   icx_linkagg:
     group: 10
     mode: static
     name: LAG1
 
-- name: create link aggregation group with auto id
+- name: Create link aggregation group with auto id
   icx_linkagg:
     group: auto
     mode: dynamic
     name: LAG2
 
-- name: delete link aggregation group
+- name: Delete link aggregation group
   icx_linkagg:
     group: 10
     state: absent

--- a/plugins/modules/network/icx/icx_logging.py
+++ b/plugins/modules/network/icx/icx_logging.py
@@ -117,7 +117,7 @@ EXAMPLES = """
   icx_logging:
     dest : on
     state: present
-- name: configure buffer level.
+- name: Configure buffer level
   icx_logging:
     dest: buffered
     level: critical
@@ -125,7 +125,7 @@ EXAMPLES = """
   icx_logging:
     aggregate:
       - { dest: buffered, level: ['notifications','errors'] }
-- name: remove logging using aggregate
+- name: Remove logging using aggregate
   icx_logging:
     aggregate:
       - { dest: console }

--- a/plugins/modules/network/icx/icx_static_route.py
+++ b/plugins/modules/network/icx/icx_static_route.py
@@ -84,12 +84,12 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure static route
+- name: Configure static route
   icx_static_route:
     prefix: 192.168.2.0/24
     next_hop: 10.0.0.1
 
-- name: remove configuration
+- name: Remove configuration
   icx_static_route:
     prefix: 192.168.2.0
     mask: 255.255.255.0
@@ -102,7 +102,7 @@ EXAMPLES = """
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
 
-- name: remove static route aggregates
+- name: Remove static route aggregates
   icx_static_route:
     aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }

--- a/plugins/modules/network/icx/icx_system.py
+++ b/plugins/modules/network/icx/icx_system.py
@@ -102,7 +102,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure hostname and domain name
+- name: Configure hostname and domain name
   icx_system:
     hostname: icx
     domain_search:
@@ -110,7 +110,7 @@ EXAMPLES = """
       - redhat.com
       - ruckus.com
 
-- name: configure radius server of type auth-port
+- name: Configure radius server of type auth-port
   icx_system:
     aaa_servers:
       - type: radius
@@ -124,7 +124,7 @@ EXAMPLES = """
           - dot1x
           - mac-auth
 
-- name: configure tacacs server
+- name: Configure tacacs server
   icx_system:
     aaa_servers:
       - type: tacacs
@@ -135,7 +135,7 @@ EXAMPLES = """
         acct_type: accounting-only
         auth_key: xyz
 
-- name: configure name servers
+- name: Configure name servers
   icx_system:
     name_servers:
       - 8.8.8.8

--- a/plugins/modules/network/icx/icx_user.py
+++ b/plugins/modules/network/icx/icx_user.py
@@ -136,22 +136,22 @@ options:
 '''
 
 EXAMPLES = """
-- name: create a new user without password
+- name: Create a new user without password
   icx_user:
     name: user1
     nopassword: true
 
-- name: create a new user with password
+- name: Create a new user with password
   icx_user:
     name: user1
     configured_password: 'newpassword'
 
-- name: remove users
+- name: Remove users
   icx_user:
     name: user1
     state: absent
 
-- name: set user privilege level to 5
+- name: Set user privilege level to 5
   icx_user:
     name: user1
     privilege: 5

--- a/plugins/modules/network/illumos/dladm_etherstub.py
+++ b/plugins/modules/network/illumos/dladm_etherstub.py
@@ -36,13 +36,13 @@ options:
 '''
 
 EXAMPLES = '''
-# Create 'stub0' etherstub
-- dladm_etherstub:
+- name: Create 'stub0' etherstub
+  dladm_etherstub:
     name: stub0
     state: present
 
-# Remove 'stub0 etherstub
-- dladm_etherstub:
+- name: Remove 'stub0 etherstub
+  dladm_etherstub:
     name: stub0
     state: absent
 '''

--- a/plugins/modules/network/illumos/dladm_vnic.py
+++ b/plugins/modules/network/illumos/dladm_vnic.py
@@ -54,21 +54,21 @@ options:
 '''
 
 EXAMPLES = '''
-# Create 'vnic0' VNIC over 'bnx0' link
-- dladm_vnic:
+- name: Create 'vnic0' VNIC over 'bnx0' link
+  dladm_vnic:
     name: vnic0
     link: bnx0
     state: present
 
-# Create VNIC with specified MAC and VLAN tag over 'aggr0'
-- dladm_vnic:
+- name: Create VNIC with specified MAC and VLAN tag over 'aggr0'
+  dladm_vnic:
     name: vnic1
     link: aggr0
     mac: '00:00:5E:00:53:23'
     vlan: 4
 
-# Remove 'vnic0' VNIC
-- dladm_vnic:
+- name: Remove 'vnic0' VNIC
+  dladm_vnic:
     name: vnic0
     link: bnx0
     state: absent

--- a/plugins/modules/network/illumos/flowadm.py
+++ b/plugins/modules/network/illumos/flowadm.py
@@ -79,8 +79,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Limit SSH traffic to 100M via vnic0 interface
-- flowadm:
+- name: Limit SSH traffic to 100M via vnic0 interface
+  flowadm:
     link: vnic0
     flow: ssh_out
     transport: tcp
@@ -88,13 +88,13 @@ EXAMPLES = '''
     maxbw: 100M
     state: present
 
-# Reset flow properties
-- flowadm:
+- name: Reset flow properties
+  flowadm:
     name: dns
     state: resetted
 
-# Configure policy for EF PHB (DSCP value of 101110 from RFC 2598) with a bandwidth of 500 Mbps and a high priority.
-- flowadm:
+- name: Configure policy for EF PHB (DSCP value of 101110 from RFC 2598) with a bandwidth of 500 Mbps and a high priority
+  flowadm:
     link: bge0
     dsfield: '0x2e:0xfc'
     maxbw: 500M

--- a/plugins/modules/network/illumos/ipadm_if.py
+++ b/plugins/modules/network/illumos/ipadm_if.py
@@ -37,13 +37,13 @@ options:
 '''
 
 EXAMPLES = '''
-# Create vnic0 interface
-- ipadm_if:
+- name: Create vnic0 interface
+  ipadm_if:
     name: vnic0
     state: enabled
 
-# Disable vnic0 interface
-- ipadm_if:
+- name: Disable vnic0 interface
+  ipadm_if:
     name: vnic0
     state: disabled
 '''

--- a/plugins/modules/network/illumos/ipadm_prop.py
+++ b/plugins/modules/network/illumos/ipadm_prop.py
@@ -44,11 +44,17 @@ options:
 '''
 
 EXAMPLES = '''
-# Set TCP receive buffer size
-- ipadm_prop: protocol=tcp property=recv_buf value=65536
+- name: Set TCP receive buffer size
+  ipadm_prop:
+    protocol: tcp
+    property: recv_buf
+    value: 65536
 
-# Reset UDP send buffer size to the default value
-- ipadm_prop: protocol=udp property=send_buf state=reset
+- name: Reset UDP send buffer size to the default value
+  ipadm_prop:
+    protocol: udp
+    property: send_buf
+    state: reset
 '''
 
 RETURN = '''

--- a/plugins/modules/network/ironware/ironware_command.py
+++ b/plugins/modules/network/ironware/ironware_command.py
@@ -62,11 +62,13 @@ options:
 '''
 
 EXAMPLES = """
-- ironware_command:
+- name: Run a command
+  ironware_command:
     commands:
       - show version
 
-- ironware_command:
+- name: Run several commands
+  ironware_command:
     commands:
       - show interfaces brief wide
       - show mpls vll

--- a/plugins/modules/network/ironware/ironware_config.py
+++ b/plugins/modules/network/ironware/ironware_config.py
@@ -150,7 +150,8 @@ options:
 '''
 
 EXAMPLES = """
-- ironware_config:
+- name: Run commands that should be configured in the section
+  ironware_config:
     lines:
       - port-name test
       - enable

--- a/plugins/modules/network/ironware/ironware_facts.py
+++ b/plugins/modules/network/ironware/ironware_facts.py
@@ -37,17 +37,17 @@ options:
 '''
 
 EXAMPLES = """
-# Collect all facts from the device
-- ironware_facts:
+- name: Collect all facts from the device
+  ironware_facts:
     gather_subset: all
 
-# Collect only the config and default facts
-- ironware_facts:
+- name: Collect only the config and default facts
+  ironware_facts:
     gather_subset:
       - config
 
-# Do not collect hardware facts
-- ironware_facts:
+- name: Do not collect hardware facts
+  ironware_facts:
     gather_subset:
       - "!hardware"
 """

--- a/plugins/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/plugins/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -336,6 +336,7 @@ requirements:
 '''
 
 EXAMPLES = '''
+# FIXME: Add examples
 '''
 
 RETURN = '''

--- a/plugins/modules/network/netvisor/pn_access_list.py
+++ b/plugins/modules/network/netvisor/pn_access_list.py
@@ -38,21 +38,21 @@ options:
 '''
 
 EXAMPLES = """
-- name: access list functionality
+- name: Access list functionality
   pn_access_list:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_scope: "local"
     state: "present"
 
-- name: access list functionality
+- name: Access list functionality
   pn_access_list:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_scope: "local"
     state: "absent"
 
-- name: access list functionality
+- name: Access list functionality
   pn_access_list:
     pn_cliswitch: "sw01"
     pn_name: "foo"

--- a/plugins/modules/network/netvisor/pn_access_list_ip.py
+++ b/plugins/modules/network/netvisor/pn_access_list_ip.py
@@ -39,14 +39,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: access list ip functionality
+- name: Access list ip functionality
   pn_access_list_ip:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_ip: "172.16.3.1"
     state: "present"
 
-- name: access list ip functionality
+- name: Access list ip functionality
   pn_access_list_ip:
     pn_cliswitch: "sw01"
     pn_name: "foo"

--- a/plugins/modules/network/netvisor/pn_admin_service.py
+++ b/plugins/modules/network/netvisor/pn_admin_service.py
@@ -84,7 +84,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: admin service functionality
+- name: Admin service functionality
   pn_admin_service:
     pn_cliswitch: "sw01"
     state: "update"
@@ -92,7 +92,7 @@ EXAMPLES = """
     pn_web: False
     pn_icmp: True
 
-- name: admin service functionality
+- name: Admin service functionality
   pn_admin_service:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_admin_session_timeout.py
+++ b/plugins/modules/network/netvisor/pn_admin_session_timeout.py
@@ -35,19 +35,19 @@ options:
 '''
 
 EXAMPLES = """
-- name: admin session timeout functionality
+- name: Admin session timeout functionality
   pn_admin_session_timeout:
     pn_cliswitch: "sw01"
     state: "update"
     pn_timeout: "61s"
 
-- name: admin session timeout functionality
+- name: Admin session timeout functionality
   pn_admin_session_timeout:
     pn_cliswitch: "sw01"
     state: "update"
     pn_timeout: "1d"
 
-- name: admin session timeout functionality
+- name: Admin session timeout functionality
   pn_admin_session_timeout:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_admin_syslog.py
+++ b/plugins/modules/network/netvisor/pn_admin_syslog.py
@@ -65,14 +65,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: admin-syslog functionality
+- name: Admin-syslog functionality
   pn_admin_syslog:
     pn_cliswitch: "sw01"
     state: "absent"
     pn_name: "foo"
     pn_scope: "local"
 
-- name: admin-syslog functionality
+- name: Admin-syslog functionality
   pn_admin_syslog:
     pn_cliswitch: "sw01"
     state: "present"
@@ -81,7 +81,7 @@ EXAMPLES = """
     pn_host: "166.68.224.46"
     pn_message_format: "structured"
 
-- name: admin-syslog functionality
+- name: Admin-syslog functionality
   pn_admin_syslog:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_cluster.py
+++ b/plugins/modules/network/netvisor/pn_cluster.py
@@ -74,7 +74,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: create spine cluster
+- name: Create spine cluster
   pn_cluster:
     state: 'present'
     pn_name: 'spine-cluster'
@@ -83,7 +83,7 @@ EXAMPLES = """
     pn_validate: True
     pn_quiet: True
 
-- name: delete spine cluster
+- name: Delete spine cluster
   pn_cluster:
     state: 'absent'
     pn_name: 'spine-cluster'

--- a/plugins/modules/network/netvisor/pn_cpu_class.py
+++ b/plugins/modules/network/netvisor/pn_cpu_class.py
@@ -50,7 +50,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: create cpu class
+- name: Create cpu class
   pn_cpu_class:
     pn_cliswitch: 'sw01'
     state: 'present'
@@ -58,14 +58,14 @@ EXAMPLES = """
     pn_rate_limit: '1000'
     pn_scope: 'local'
 
-- name: delete cpu class
+- name: Delete cpu class
   pn_cpu_class:
     pn_cliswitch: 'sw01'
     state: 'absent'
     pn_name: 'icmp'
 
 
-- name: modify cpu class
+- name: Modify cpu class
   pn_cpu_class:
     pn_cliswitch: 'sw01'
     state: 'update'

--- a/plugins/modules/network/netvisor/pn_cpu_mgmt_class.py
+++ b/plugins/modules/network/netvisor/pn_cpu_mgmt_class.py
@@ -44,7 +44,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: cpu mgmt class modify ingress policers
+- name: Cpu mgmt class modify ingress policers
   pn_cpu_mgmt_class:
     pn_cliswitch: "sw01"
     state: "update"
@@ -52,7 +52,7 @@ EXAMPLES = """
     pn_rate_limit: "10000"
     pn_burst_size: "14000"
 
-- name: cpu mgmt class modify ingress policers
+- name: Cpu mgmt class modify ingress policers
   pn_cpu_mgmt_class:
     pn_cliswitch: "sw01"
     state: "update"
@@ -60,7 +60,7 @@ EXAMPLES = """
     pn_burst_size: "8000"
     pn_rate_limit: "100000"
 
-- name: cpu mgmt class modify ingress policers
+- name: Cpu mgmt class modify ingress policers
   pn_cpu_mgmt_class:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_dhcp_filter.py
+++ b/plugins/modules/network/netvisor/pn_dhcp_filter.py
@@ -39,21 +39,21 @@ options:
 '''
 
 EXAMPLES = """
-- name: dhcp filter create
+- name: Dhcp filter create
   pn_dhcp_filter:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     state: "present"
     pn_trusted_ports: "1"
 
-- name: dhcp filter delete
+- name: Dhcp filter delete
   pn_dhcp_filter:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     state: "absent"
     pn_trusted_ports: "1"
 
-- name: dhcp filter modify
+- name: Dhcp filter modify
   pn_dhcp_filter:
     pn_cliswitch: "sw01"
     pn_name: "foo"

--- a/plugins/modules/network/netvisor/pn_dscp_map.py
+++ b/plugins/modules/network/netvisor/pn_dscp_map.py
@@ -39,14 +39,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: dscp map create
+- name: Dscp map create
   pn_dscp_map:
     pn_cliswitch: "sw01"
     state: "present"
     pn_name: "foo"
     pn_scope: "local"
 
-- name: dscp map delete
+- name: Dscp map delete
   pn_dscp_map:
     pn_cliswitch: "sw01"
     state: "absent"

--- a/plugins/modules/network/netvisor/pn_dscp_map_pri_map.py
+++ b/plugins/modules/network/netvisor/pn_dscp_map_pri_map.py
@@ -44,7 +44,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: dscp map pri map modify
+- name: Dscp map pri map modify
   pn_dscp_map_pri_map:
     pn_cliswitch: 'sw01'
     state: 'update'
@@ -52,7 +52,7 @@ EXAMPLES = """
     pn_pri: '0'
     pn_dsmap: '40'
 
-- name: dscp map pri map modify
+- name: Dscp map pri map modify
   pn_dscp_map_pri_map:
     pn_cliswitch: 'sw01'
     state: 'update'

--- a/plugins/modules/network/netvisor/pn_ipv6security_raguard.py
+++ b/plugins/modules/network/netvisor/pn_ipv6security_raguard.py
@@ -56,13 +56,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: ipv6 security ragurad create
+- name: Ipv6 security ragurad create
   pn_ipv6security_raguard:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_device: "host"
 
-- name: ipv6 security ragurad create
+- name: Ipv6 security ragurad create
   pn_ipv6security_raguard:
     pn_cliswitch: "sw01"
     pn_name: "foo1"
@@ -71,7 +71,7 @@ EXAMPLES = """
     pn_prefix_list: "sample"
     pn_router_priority: "low"
 
-- name: ipv6 security ragurad modify
+- name: Ipv6 security ragurad modify
   pn_ipv6security_raguard:
     pn_cliswitch: "sw01"
     pn_name: "foo1"
@@ -79,7 +79,7 @@ EXAMPLES = """
     pn_router_priority: "medium"
     state: "update"
 
-- name: ipv6 security ragurad delete
+- name: Ipv6 security ragurad delete
   pn_ipv6security_raguard:
     pn_cliswitch: "sw01"
     pn_name: "foo"

--- a/plugins/modules/network/netvisor/pn_ipv6security_raguard_port.py
+++ b/plugins/modules/network/netvisor/pn_ipv6security_raguard_port.py
@@ -39,13 +39,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: ipv6 security raguard port add
+- name: Ipv6 security raguard port add
   pn_ipv6security_raguard_port:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_ports: "1"
 
-- name: ipv6 security raguard port remove
+- name: Ipv6 security raguard port remove
   pn_ipv6security_raguard_port:
     pn_cliswitch: "sw01"
     pn_name: "foo"

--- a/plugins/modules/network/netvisor/pn_ipv6security_raguard_vlan.py
+++ b/plugins/modules/network/netvisor/pn_ipv6security_raguard_vlan.py
@@ -39,19 +39,19 @@ options:
 '''
 
 EXAMPLES = """
-- name: ipv6 security raguard vlan add
+- name: Ipv6 security raguard vlan add
   pn_ipv6security_raguard_vlan:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_vlans: "100-105"
 
-- name: ipv6 security raguard vlan add
+- name: Ipv6 security raguard vlan add
   pn_ipv6security_raguard_vlan:
     pn_cliswitch: "sw01"
     pn_name: "foo"
     pn_vlans: "100"
 
-- name: ipv6 security raguard vlan remove
+- name: Ipv6 security raguard vlan remove
   pn_ipv6security_raguard_vlan:
     pn_cliswitch: "sw01"
     pn_name: "foo"

--- a/plugins/modules/network/netvisor/pn_log_audit_exception.py
+++ b/plugins/modules/network/netvisor/pn_log_audit_exception.py
@@ -53,7 +53,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: create a log-audit-exception
+- name: Create a log-audit-exception
   pn_log_audit_exception:
     pn_audit_type: "cli"
     pn_pattern: "test"
@@ -61,7 +61,7 @@ EXAMPLES = """
     pn_access: "any"
     pn_scope: "local"
 
-- name: delete a log-audit-exception
+- name: Delete a log-audit-exception
   pn_log_audit_exception:
     pn_audit_type: "shell"
     pn_pattern: "test"

--- a/plugins/modules/network/netvisor/pn_port_config.py
+++ b/plugins/modules/network/netvisor/pn_port_config.py
@@ -166,14 +166,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: port config modify
+- name: Port config modify
   pn_port_config:
     pn_cliswitch: "sw01"
     state: "update"
     pn_port: "all"
     pn_dscp_map: "foo"
 
-- name: port config modify
+- name: Port config modify
   pn_port_config:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_port_cos_bw.py
+++ b/plugins/modules/network/netvisor/pn_port_cos_bw.py
@@ -54,7 +54,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: port cos bw modify
+- name: Port cos bw modify
   pn_port_cos_bw:
     pn_cliswitch: "sw01"
     state: "update"
@@ -62,7 +62,7 @@ EXAMPLES = """
     pn_cos: "0"
     pn_min_bw_guarantee: "60"
 
-- name: port cos bw modify
+- name: Port cos bw modify
   pn_port_cos_bw:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_port_cos_rate_setting.py
+++ b/plugins/modules/network/netvisor/pn_port_cos_rate_setting.py
@@ -75,7 +75,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: port cos rate modify
+- name: Port cos rate modify
   pn_port_cos_rate_setting:
     pn_cliswitch: "sw01"
     state: "update"
@@ -85,7 +85,7 @@ EXAMPLES = """
     pn_cos2_rate: "1000"
     pn_cos0_rate: "1000"
 
-- name: port cos rate modify
+- name: Port cos rate modify
   pn_port_cos_rate_setting:
     pn_cliswitch: "sw01"
     state: "update"

--- a/plugins/modules/network/netvisor/pn_prefix_list_network.py
+++ b/plugins/modules/network/netvisor/pn_prefix_list_network.py
@@ -44,7 +44,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: prefix list network add
+- name: Prefix list network add
   pn_prefix_list_network:
     pn_cliswitch: "sw01"
     pn_name: "foo"
@@ -52,7 +52,7 @@ EXAMPLES = """
     pn_netmask: "24"
     state: "present"
 
-- name: prefix list network remove
+- name: Prefix list network remove
   pn_prefix_list_network:
     pn_cliswitch: "sw01"
     state: "absent"

--- a/plugins/modules/network/netvisor/pn_show.py
+++ b/plugins/modules/network/netvisor/pn_show.py
@@ -58,19 +58,19 @@ options:
 '''
 
 EXAMPLES = """
-- name: run the vlan-show command
+- name: Run the vlan-show command
   pn_show:
     pn_command: 'vlan-show'
     pn_parameters: id,scope,ports
     pn_options: 'layout vertical'
 
-- name: run the vlag-show command
+- name: Run the vlag-show command
   pn_show:
     pn_command: 'vlag-show'
     pn_parameters: 'id,name,cluster,mode'
     pn_options: 'no-show-headers'
 
-- name: run the cluster-show command
+- name: Run the cluster-show command
   pn_show:
     pn_command: 'cluster-show'
 """

--- a/plugins/modules/network/netvisor/pn_snmp_trap_sink.py
+++ b/plugins/modules/network/netvisor/pn_snmp_trap_sink.py
@@ -48,7 +48,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: snmp trap sink functionality
+- name: Snmp trap sink functionality
   pn_snmp_trap_sink:
     pn_cliswitch: "sw01"
     state: "present"
@@ -56,7 +56,7 @@ EXAMPLES = """
     pn_type: "TRAP_TYPE_V2_INFORM"
     pn_dest_host: "192.168.67.8"
 
-- name: snmp trap sink functionality
+- name: Snmp trap sink functionality
   pn_snmp_trap_sink:
     pn_cliswitch: "sw01"
     state: "absent"

--- a/plugins/modules/network/netvisor/pn_snmp_vacm.py
+++ b/plugins/modules/network/netvisor/pn_snmp_vacm.py
@@ -51,21 +51,21 @@ options:
 '''
 
 EXAMPLES = """
-- name: create snmp vacm
+- name: Create snmp vacm
   pn_snmp_vacm:
     pn_cliswitch: "sw01"
     state: "present"
     pn_user_name: "foo"
     pn_user_type: "rouser"
 
-- name: update snmp vacm
+- name: Update snmp vacm
   pn_snmp_vacm:
     pn_cliswitch: "sw01"
     state: "update"
     pn_user_name: "foo"
     pn_user_type: "rwuser"
 
-- name: delete snmp vacm
+- name: Delete snmp vacm
   pn_snmp_vacm:
     pn_cliswitch: "sw01"
     state: "absent"

--- a/plugins/modules/network/netvisor/pn_trunk.py
+++ b/plugins/modules/network/netvisor/pn_trunk.py
@@ -136,13 +136,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: create trunk
+- name: Create trunk
   pn_trunk:
     state: 'present'
     pn_name: 'spine-to-leaf'
     pn_ports: '11,12,13,14'
 
-- name: delete trunk
+- name: Delete trunk
   pn_trunk:
     state: 'absent'
     pn_name: 'spine-to-leaf'

--- a/plugins/modules/network/netvisor/pn_vlag.py
+++ b/plugins/modules/network/netvisor/pn_vlag.py
@@ -98,7 +98,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: create a VLAG
+- name: Create a VLAG
   pn_vlag:
     state: 'present'
     pn_name: spine-to-leaf
@@ -107,7 +107,7 @@ EXAMPLES = """
     pn_peer_switch: spine02
     pn_mode: 'active-active'
 
-- name: delete VLAGs
+- name: Delete VLAGs
   pn_vlag:
     state: 'absent'
     pn_name: spine-to-leaf

--- a/plugins/modules/network/netvisor/pn_vlan.py
+++ b/plugins/modules/network/netvisor/pn_vlan.py
@@ -82,13 +82,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: create a VLAN
+- name: Create a VLAN
   pn_vlan:
     state: 'present'
     pn_vlanid: 1854
     pn_scope: fabric
 
-- name: delete VLANs
+- name: Delete VLANs
   pn_vlan:
     state: 'absent'
     pn_vlanid: 1854

--- a/plugins/modules/network/netvisor/pn_vrouter.py
+++ b/plugins/modules/network/netvisor/pn_vrouter.py
@@ -117,14 +117,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: create vrouter
+- name: Create vrouter
   pn_vrouter:
     state: 'present'
     pn_name: 'ansible-vrouter'
     pn_vnet: 'ansible-fab-global'
     pn_router_id: 208.74.182.1
 
-- name: delete vrouter
+- name: Delete vrouter
   pn_vrouter:
     state: 'absent'
     pn_name: 'ansible-vrouter'

--- a/plugins/modules/network/netvisor/pn_vrouter_packet_relay.py
+++ b/plugins/modules/network/netvisor/pn_vrouter_packet_relay.py
@@ -52,14 +52,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: vRouter packet relay add
+- name: VRouter packet relay add
   pn_vrouter_packet_relay:
     pn_cliswitch: "sw01"
     pn_forward_ip: "192.168.10.1"
     pn_nic: "eth0.4092"
     pn_vrouter_name: "sw01-vrouter"
 
-- name: vRouter packet relay remove
+- name: VRouter packet relay remove
   pn_vrouter_packet_relay:
     pn_cliswitch: "sw01"
     state: "absent"

--- a/plugins/modules/network/netvisor/pn_vrouter_pim_config.py
+++ b/plugins/modules/network/netvisor/pn_vrouter_pim_config.py
@@ -48,7 +48,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: pim config modify
+- name: Pim config modify
   pn_vrouter_pim_config:
     pn_cliswitch: '192.168.1.1'
     pn_query_interval: '10'

--- a/plugins/modules/network/netvisor/pn_vrouterbgp.py
+++ b/plugins/modules/network/netvisor/pn_vrouterbgp.py
@@ -134,14 +134,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: add vrouter-bgp
+- name: Add vrouter-bgp
   pn_vrouterbgp:
     state: 'present'
     pn_vrouter_name: 'ansible-vrouter'
     pn_neighbor: 104.104.104.1
     pn_remote_as: 1800
 
-- name: remove vrouter-bgp
+- name: Remove vrouter-bgp
   pn_vrouterbgp:
     state: 'absent'
     pn_name: 'ansible-vrouter'

--- a/plugins/modules/network/netvisor/pn_vrouterlbif.py
+++ b/plugins/modules/network/netvisor/pn_vrouterlbif.py
@@ -67,13 +67,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: add vrouter-loopback-interface
+- name: Add vrouter-loopback-interface
   pn_vrouterlbif:
     state: 'present'
     pn_vrouter_name: 'ansible-vrouter'
     pn_interface_ip: '104.104.104.1'
 
-- name: remove vrouter-loopback-interface
+- name: Remove vrouter-loopback-interface
   pn_vrouterlbif:
     state: 'absent'
     pn_vrouter_name: 'ansible-vrouter'

--- a/plugins/modules/network/netvisor/pn_vtep.py
+++ b/plugins/modules/network/netvisor/pn_vtep.py
@@ -60,7 +60,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: create vtep
+- name: Create vtep
   pn_vtep:
     pn_cliswitch: 'sw01'
     pn_name: 'foo'
@@ -69,7 +69,7 @@ EXAMPLES = """
     pn_location: 'sw01'
     pn_virtual_ip: "22.22.22.1"
 
-- name: delete vtep
+- name: Delete vtep
   pn_vtep:
     pn_cliswitch: 'sw01'
     state: 'absent'

--- a/plugins/modules/network/nos/nos_command.py
+++ b/plugins/modules/network/nos/nos_command.py
@@ -64,22 +64,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     nos_command:
       commands: show version
 
-  - name: run show version and check to see if output contains NOS
+  - name: Run show version and check to see if output contains NOS
     nos_command:
       commands: show version
       wait_for: result[0] contains NOS
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     nos_command:
       commands:
         - show version
         - show interfaces
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     nos_command:
       commands:
         - show version
@@ -87,7 +87,7 @@ tasks:
       wait_for:
         - result[0] contains NOS
         - result[1] contains Te
-  - name: run command that requires answering a prompt
+  - name: Run command that requires answering a prompt
     nos_command:
       commands:
         - command: 'clear sessions'

--- a/plugins/modules/network/nos/nos_config.py
+++ b/plugins/modules/network/nos/nos_config.py
@@ -149,11 +149,11 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure top level configuration
+- name: Configure top level configuration
   nos_config:
     lines: logging raslog console INFO
 
-- name: configure interface settings
+- name: Configure interface settings
   nos_config:
     lines:
       - description test interface
@@ -161,7 +161,7 @@ EXAMPLES = """
     parents:
       - interface TenGigabitEthernet 104/0/1
 
-- name: configure multiple interfaces
+- name: Configure multiple interfaces
   nos_config:
     lines:
       - lacp timeout long
@@ -170,7 +170,7 @@ EXAMPLES = """
     - interface TenGigabitEthernet 104/0/1
     - interface TenGigabitEthernet 104/0/2
 
-- name: load new acl into device
+- name: Load new acl into device
   nos_config:
     lines:
       - seq 10 permit ip host 1.1.1.1 any log
@@ -182,12 +182,12 @@ EXAMPLES = """
     before: no ip access-list extended test
     match: exact
 
-- name: check the running-config against master config
+- name: Check the running-config against master config
   nos_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
-- name: configurable backup path
+- name: Configurable backup path
   nos_config:
     lines: logging raslog console INFO
     backup: yes

--- a/plugins/modules/network/onyx/onyx_aaa.py
+++ b/plugins/modules/network/onyx/onyx_aaa.py
@@ -36,7 +36,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configures aaa
+- name: Configures aaa
   onyx_aaa:
     tacacs_accounting_enabled: yes
     auth_default_user: monitor

--- a/plugins/modules/network/onyx/onyx_bfd.py
+++ b/plugins/modules/network/onyx/onyx_bfd.py
@@ -50,7 +50,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configures bfd
+- name: Configures bfd
   onyx_bfd:
     shutdown: yes
     vrf: 5

--- a/plugins/modules/network/onyx/onyx_bgp.py
+++ b/plugins/modules/network/onyx/onyx_bgp.py
@@ -73,7 +73,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure bgp
+- name: Configure bgp
   onyx_bgp:
     as_number: 320
     router_id: 10.3.3.3

--- a/plugins/modules/network/onyx/onyx_buffer_pool.py
+++ b/plugins/modules/network/onyx/onyx_buffer_pool.py
@@ -35,7 +35,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure buffer pool
+- name: Configure buffer pool
   onyx_buffer_pool:
     name: roce
     pool_type: lossless

--- a/plugins/modules/network/onyx/onyx_command.py
+++ b/plugins/modules/network/onyx/onyx_command.py
@@ -67,22 +67,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     onyx_command:
       commands: show version
 
-  - name: run show version and check to see if output contains MLNXOS
+  - name: Run show version and check to see if output contains MLNXOS
     onyx_command:
       commands: show version
       wait_for: result[0] contains MLNXOS
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     onyx_command:
       commands:
         - show version
         - show interfaces
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     onyx_command:
       commands:
         - show version

--- a/plugins/modules/network/onyx/onyx_igmp.py
+++ b/plugins/modules/network/onyx/onyx_igmp.py
@@ -51,7 +51,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure igmp
+- name: Configure igmp
   onyx_igmp:
     state: enabled
     unregistered_multicast: flood

--- a/plugins/modules/network/onyx/onyx_igmp_interface.py
+++ b/plugins/modules/network/onyx/onyx_igmp_interface.py
@@ -29,7 +29,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure igmp interface
+- name: Configure igmp interface
   onyx_igmp_interface:
     state: enabled
     name: Eth1/1

--- a/plugins/modules/network/onyx/onyx_igmp_vlan.py
+++ b/plugins/modules/network/onyx/onyx_igmp_vlan.py
@@ -74,7 +74,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure igmp vlan
+- name: Configure igmp vlan
   onyx_igmp_vlan:
     state: enabled
     vlan_id: 10

--- a/plugins/modules/network/onyx/onyx_interface.py
+++ b/plugins/modules/network/onyx/onyx_interface.py
@@ -72,19 +72,19 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure interface
+- name: Configure interface
   onyx_interface:
       name: Eth1/2
       description: test-interface
       speed: 100G
       mtu: 512
 
-- name: make interface up
+- name: Make interface up
   onyx_interface:
     name: Eth1/2
     enabled: True
 
-- name: make interface down
+- name: Make interface down
   onyx_interface:
     name: Eth1/2
     enabled: False

--- a/plugins/modules/network/onyx/onyx_l2_interface.py
+++ b/plugins/modules/network/onyx/onyx_l2_interface.py
@@ -40,12 +40,12 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure Layer-2 interface
+- name: Configure Layer-2 interface
   onyx_l2_interface:
     name: Eth1/1
     mode: access
     access_vlan: 30
-- name: remove Layer-2 interface configuration
+- name: Remove Layer-2 interface configuration
   onyx_l2_interface:
     name: Eth1/1
     state: absent

--- a/plugins/modules/network/onyx/onyx_linkagg.py
+++ b/plugins/modules/network/onyx/onyx_linkagg.py
@@ -47,14 +47,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure link aggregation group
+- name: Configure link aggregation group
   onyx_linkagg:
     name: Po1
     members:
       - Eth1/1
       - Eth1/2
 
-- name: remove configuration
+- name: Remove configuration
   onyx_linkagg:
     name: Po1
     state: absent

--- a/plugins/modules/network/onyx/onyx_magp.py
+++ b/plugins/modules/network/onyx/onyx_magp.py
@@ -39,7 +39,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: run add vlan interface with magp
+- name: Run add vlan interface with magp
   onyx_magp:
     magp_id: 103
     router_ip: 192.168.8.2

--- a/plugins/modules/network/onyx/onyx_mlag_ipl.py
+++ b/plugins/modules/network/onyx/onyx_mlag_ipl.py
@@ -35,14 +35,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: run configure ipl
+- name: Run configure ipl
   onyx_mlag_ipl:
     name: Po1
     vlan_interface: Vlan 322
     state: present
     peer_address: 192.168.7.1
 
-- name: run remove ipl
+- name: Run remove ipl
   onyx_mlag_ipl:
     name: Po1
     state: absent

--- a/plugins/modules/network/onyx/onyx_mlag_vip.py
+++ b/plugins/modules/network/onyx/onyx_mlag_vip.py
@@ -38,7 +38,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure mlag-vip
+- name: Configure mlag-vip
   onyx_mlag_vip:
     ipaddress: 50.3.3.1/24
     group_name: ansible-test-group

--- a/plugins/modules/network/onyx/onyx_ntp.py
+++ b/plugins/modules/network/onyx/onyx_ntp.py
@@ -58,7 +58,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure NTP
+- name: Configure NTP
   onyx_ntp:
     state: enabled
     authenticate_state: enabled

--- a/plugins/modules/network/onyx/onyx_ntp_servers_peers.py
+++ b/plugins/modules/network/onyx/onyx_ntp_servers_peers.py
@@ -81,7 +81,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure NTP peers and servers
+- name: Configure NTP peers and servers
   onyx_ntp_peers_servers:
     peer:
        - ip_or_name: 1.1.1.1

--- a/plugins/modules/network/onyx/onyx_ospf.py
+++ b/plugins/modules/network/onyx/onyx_ospf.py
@@ -44,7 +44,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: add ospf router to interface
+- name: Add ospf router to interface
   onyx_ospf:
     ospf: 2
     router_id: 192.168.8.2

--- a/plugins/modules/network/onyx/onyx_pfc_interface.py
+++ b/plugins/modules/network/onyx/onyx_pfc_interface.py
@@ -35,7 +35,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure PFC
+- name: Configure PFC
   onyx_pfc_interface:
     name: Eth1/1
     state: enabled

--- a/plugins/modules/network/onyx/onyx_protocol.py
+++ b/plugins/modules/network/onyx/onyx_protocol.py
@@ -59,7 +59,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: enable protocols for MLAG
+- name: Enable protocols for MLAG
   onyx_protocol:
     lacp: enabled
     spanning_tree: disabled

--- a/plugins/modules/network/onyx/onyx_ptp_global.py
+++ b/plugins/modules/network/onyx/onyx_ptp_global.py
@@ -39,7 +39,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure PTP
+- name: Configure PTP
   onyx_ptp_global:
     ntp_state: enabled
     ptp_state: disabled

--- a/plugins/modules/network/onyx/onyx_ptp_interface.py
+++ b/plugins/modules/network/onyx/onyx_ptp_interface.py
@@ -45,7 +45,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure PTP interface
+- name: Configure PTP interface
   onyx_ptp_interface:
     state: enabled
     name: Eth1/1

--- a/plugins/modules/network/onyx/onyx_qos.py
+++ b/plugins/modules/network/onyx/onyx_qos.py
@@ -39,7 +39,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure QoS
+- name: Configure QoS
   onyx_QoS:
     interfaces:
       - Mpo7
@@ -48,7 +48,7 @@ EXAMPLES = """
     rewrite_pcp: disabled
     rewrite_dscp: enabled
 
-- name: configure QoS
+- name: Configure QoS
   onyx_QoS:
     interfaces:
       - Eth1/1

--- a/plugins/modules/network/onyx/onyx_snmp.py
+++ b/plugins/modules/network/onyx/onyx_snmp.py
@@ -111,7 +111,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure SNMP
+- name: Configure SNMP
   onyx_snmp:
     state_enabled: yes
     contact_name: sara

--- a/plugins/modules/network/onyx/onyx_snmp_hosts.py
+++ b/plugins/modules/network/onyx/onyx_snmp_hosts.py
@@ -73,13 +73,13 @@ options:
 '''
 
 EXAMPLES = """
-- name: enables snmp host
+- name: Enables snmp host
   onyx_snmp_hosts:
       hosts:
        - name: 1.1.1.1
          enabled: true
 
-- name: configures snmp host with version 2c
+- name: Configures snmp host with version 2c
   onyx_snmp_hosts:
       hosts:
          - name: 2.3.2.4
@@ -88,7 +88,7 @@ EXAMPLES = """
            port: 66
            version: 2c
 
-- name: configures snmp host with version 3 and configures it with user as sara
+- name: Configures snmp host with version 3 and configures it with user as sara
   onyx_snmp_hosts:
        hosts:
          - name: 2.3.2.4
@@ -102,7 +102,7 @@ EXAMPLES = """
            privacy_type: 3des
            privacy_password: nojfd8uherwiugfh
 
-- name: deletes the snmp host
+- name: Deletes the snmp host
   onyx_snmp_hosts:
         hosts:
           - name: 2.3.2.4

--- a/plugins/modules/network/onyx/onyx_snmp_users.py
+++ b/plugins/modules/network/onyx/onyx_snmp_users.py
@@ -54,31 +54,31 @@ options:
 '''
 
 EXAMPLES = """
-- name: enables snmp user
+- name: Enables snmp user
   onyx_snmp_users:
     users:
        - name: sara
          enabled: true
 
-- name: enables snmp set requests
+- name: Enables snmp set requests
   onyx_snmp_users:
     users:
        - name: sara
          set_access_enabled: yes
 
-- name: enables user require privacy
+- name: Enables user require privacy
   onyx_snmp_users:
     users:
        - name: sara
          require_privacy: true
 
-- name: configures user hash type
+- name: Configures user hash type
   onyx_snmp_users:
     users:
        - auth_type: md5
          auth_password: 1297sara1234sara
 
-- name: configures user capability_level
+- name: Configures user capability_level
   onyx_snmp_users:
     users:
         - name: sara

--- a/plugins/modules/network/onyx/onyx_syslog_files.py
+++ b/plugins/modules/network/onyx/onyx_syslog_files.py
@@ -62,14 +62,14 @@ options:
 '''
 
 EXAMPLES = """
-- name: syslog delete old files
+- name: Syslog delete old files
 - onyx_syslog_files:
     delete_group: oldest
-- name: syslog upload file
+- name: Syslog upload file
 - onyx_syslog_files:
     upload_url: scp://username:password@hostnamepath/filename
     upload_file: current
-- name: syslog rotation force, frequency and max number
+- name: Syslog rotation force, frequency and max number
 - onyx_syslog_files:
     rotation:
         force: true

--- a/plugins/modules/network/onyx/onyx_syslog_remote.py
+++ b/plugins/modules/network/onyx/onyx_syslog_remote.py
@@ -68,30 +68,30 @@ options:
 '''
 
 EXAMPLES = """
-- name: remote logging port 8080
+- name: Remote logging port 8080
 - onyx_syslog_remote:
     host: 10.10.10.10
     port: 8080
 
-- name: remote logging trap override
+- name: Remote logging trap override
 - onyx_syslog_remote:
     host: 10.10.10.10
     trap_override:
         - override_class: events
           override_priority: emerg
 
-- name: remote logging trap emerg
+- name: Remote logging trap emerg
 - onyx_syslog_remote:
     host: 10.10.10.10
     trap: emerg
 
-- name: remote logging filter include 'ERR'
+- name: Remote logging filter include 'ERR'
 - onyx_syslog_remote:
     host: 10.10.10.10
     filter: include
     filter_str: /ERR/
 
-- name: disable remote logging with class events
+- name: Disable remote logging with class events
 - onyx_syslog_remote:
     enabled: False
     host: 10.10.10.10

--- a/plugins/modules/network/onyx/onyx_traffic_class.py
+++ b/plugins/modules/network/onyx/onyx_traffic_class.py
@@ -65,7 +65,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure traffic class
+- name: Configure traffic class
   onyx_traffic_class:
     interfaces:
       - Eth1/1

--- a/plugins/modules/network/onyx/onyx_username.py
+++ b/plugins/modules/network/onyx/onyx_username.py
@@ -68,32 +68,32 @@ options:
 '''
 
 EXAMPLES = """
-- name: create new user
+- name: Create new user
   onyx_username:
       username: anass
 
-- name: set the user full-name
+- name: Set the user full-name
   onyx_username:
       username: anass
       full_name: anasshami
 
-- name: set the user encrypted password
+- name: Set the user encrypted password
   onyx_username:
       username: anass
       password: 12345
       encrypted_password: True
 
-- name: set the user capability
+- name: Set the user capability
   onyx_username:
       username: anass
       capability: monitor
 
-- name: reset the user capability
+- name: Reset the user capability
   onyx_username:
       username: anass
       reset_capability: True
 
-- name: remove the user configuration
+- name: Remove the user configuration
   onyx_username:
       username: anass
       state: absent

--- a/plugins/modules/network/onyx/onyx_vlan.py
+++ b/plugins/modules/network/onyx/onyx_vlan.py
@@ -36,12 +36,12 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure VLAN ID and name
+- name: Configure VLAN ID and name
   onyx_vlan:
     vlan_id: 20
     name: test-vlan
 
-- name: remove configuration
+- name: Remove configuration
   onyx_vlan:
     state: absent
 """

--- a/plugins/modules/network/onyx/onyx_vxlan.py
+++ b/plugins/modules/network/onyx/onyx_vxlan.py
@@ -44,7 +44,7 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure Vxlan
+- name: Configure Vxlan
   onyx_vxlan:
     nve_id: 1
     loopback_id: 1

--- a/plugins/modules/network/onyx/onyx_wjh.py
+++ b/plugins/modules/network/onyx/onyx_wjh.py
@@ -42,25 +42,25 @@ options:
 '''
 
 EXAMPLES = """
-- name: enable wjh
+- name: Enable wjh
   onyx_wjh:
       group: forwarding
       enabled: True
 
-- name: disable wjh
+- name: Disable wjh
   onyx_wjh:
       group: forwarding
       enabled: False
 
-- name: enable auto-export
+- name: Enable auto-export
   onyx_wjh:
         auto_export: True
         export_group: forwarding
-- name: disable auto-export
+- name: Disable auto-export
   onyx_wjh:
         auto_export: False
         export_group: forwarding
-- name: clear pcap file
+- name: Clear pcap file
   onyx_wjh:
         clear_group: auto-export
 """

--- a/plugins/modules/network/ordnance/ordnance_config.py
+++ b/plugins/modules/network/ordnance/ordnance_config.py
@@ -125,12 +125,12 @@ vars:
     transport: cli
 
 ---
-- name: configure top level configuration
+- name: Configure top level configuration
   ordnance_config:
     lines: hostname {{ inventory_hostname }}
     provider: "{{ cli }}"
 
-- name: configure interface settings
+- name: Configure interface settings
   ordnance_config:
     lines:
       - description test interface
@@ -138,7 +138,7 @@ vars:
     parents: interface Ethernet1
     provider: "{{ cli }}"
 
-- name: configure bgp router
+- name: Configure bgp router
   ordnance_config:
     lines:
       - neighbor 1.1.1.1 remote-as 1234

--- a/plugins/modules/network/ordnance/ordnance_facts.py
+++ b/plugins/modules/network/ordnance/ordnance_facts.py
@@ -43,19 +43,19 @@ vars:
     transport: cli
 
 ---
-# Collect all facts from the device
-- ordnance_facts:
+- name: Collect all facts from the device
+  ordnance_facts:
     gather_subset: all
     provider: "{{ cli }}"
 
-# Collect only the config and default facts
-- ordnance_facts:
+- name: Collect only the config and default facts
+  ordnance_facts:
     gather_subset:
       - config
     provider: "{{ cli }}"
 
-# Do not collect hardware facts
-- ordnance_facts:
+- name: Do not collect hardware facts
+  ordnance_facts:
     gather_subset:
       - "!hardware"
     provider: "{{ cli }}"

--- a/plugins/modules/network/panos/panos_admin.py
+++ b/plugins/modules/network/panos/panos_admin.py
@@ -58,7 +58,7 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Set the password of user admin to "badpassword"
 # Doesn't commit the candidate config
-  - name: set admin password
+  - name: Set admin password
     panos_admin:
       ip_address: "192.168.1.1"
       password: "admin"

--- a/plugins/modules/network/panos/panos_admpwd.py
+++ b/plugins/modules/network/panos/panos_admpwd.py
@@ -56,7 +56,7 @@ options:
 EXAMPLES = '''
 # Tries for 10 times to set the admin password of 192.168.1.1 to "badpassword"
 # via SSH, authenticating using key /tmp/ssh.key
-- name: set admin password
+- name: Set admin password
   panos_admpwd:
     ip_address: "192.168.1.1"
     username: "admin"

--- a/plugins/modules/network/panos/panos_cert_gen_ssh.py
+++ b/plugins/modules/network/panos/panos_cert_gen_ssh.py
@@ -68,7 +68,7 @@ options:
 
 EXAMPLES = '''
 # Generates a new self-signed certificate using ssh
-- name: generate self signed certificate
+- name: Generate self signed certificate
   panos_cert_gen_ssh:
     ip_address: "192.168.1.1"
     password: "paloalto"

--- a/plugins/modules/network/panos/panos_check.py
+++ b/plugins/modules/network/panos/panos_check.py
@@ -51,14 +51,14 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # single check on 192.168.1.1 with credentials admin/admin
-- name: check if ready
+- name: Check if ready
   panos_check:
     ip_address: "192.168.1.1"
     password: "admin"
 
 # check for 10 times, every 30 seconds, if device 192.168.1.1
 # is ready, using credentials admin/admin
-- name: wait for reboot
+- name: Wait for reboot
   panos_check:
     ip_address: "192.168.1.1"
     password: "admin"

--- a/plugins/modules/network/panos/panos_commit.py
+++ b/plugins/modules/network/panos/panos_commit.py
@@ -82,8 +82,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Commit candidate config on 192.168.1.1 in sync mode
-- panos_commit:
+- name: Commit candidate config on 192.168.1.1 in sync mode
+  panos_commit:
     ip_address: "192.168.1.1"
     username: "admin"
     password: "admin"

--- a/plugins/modules/network/panos/panos_dag.py
+++ b/plugins/modules/network/panos/panos_dag.py
@@ -52,7 +52,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: dag
+- name: Dag
   panos_dag:
     ip_address: "192.168.1.1"
     password: "admin"

--- a/plugins/modules/network/panos/panos_import.py
+++ b/plugins/modules/network/panos/panos_import.py
@@ -61,7 +61,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # import software image PanOS_vm-6.1.1 on 192.168.1.1
-- name: import software image into PAN-OS
+- name: Import software image into PAN-OS
   panos_import:
     ip_address: 192.168.1.1
     username: admin

--- a/plugins/modules/network/panos/panos_interface.py
+++ b/plugins/modules/network/panos/panos_interface.py
@@ -60,7 +60,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: enable DHCP client on ethernet1/1 in zone public
+- name: Enable DHCP client on ethernet1/1 in zone public
   interface:
     password: "admin"
     ip_address: "192.168.1.1"

--- a/plugins/modules/network/panos/panos_lic.py
+++ b/plugins/modules/network/panos/panos_lic.py
@@ -54,7 +54,7 @@ EXAMPLES = '''
     - hosts: localhost
       connection: local
       tasks:
-        - name: fetch license
+        - name: Fetch license
           panos_lic:
             ip_address: "192.168.1.1"
             password: "paloalto"

--- a/plugins/modules/network/panos/panos_loadcfg.py
+++ b/plugins/modules/network/panos/panos_loadcfg.py
@@ -48,14 +48,14 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # Import and load config file from URL
-  - name: import configuration
+  - name: Import configuration
     panos_import:
       ip_address: "192.168.1.1"
       password: "admin"
       url: "{{ConfigURL}}"
       category: "configuration"
     register: result
-  - name: load configuration
+  - name: Load configuration
     panos_loadcfg:
       ip_address: "192.168.1.1"
       password: "admin"

--- a/plugins/modules/network/panos/panos_match_rule.py
+++ b/plugins/modules/network/panos/panos_match_rule.py
@@ -102,7 +102,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: check security rules for Google DNS
+- name: Check security rules for Google DNS
   panos_match_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -116,7 +116,7 @@ EXAMPLES = '''
   register: result
 - debug: msg='{{result.stdout_lines}}'
 
-- name: check security rules inbound SSH with user match
+- name: Check security rules inbound SSH with user match
   panos_match_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -130,7 +130,7 @@ EXAMPLES = '''
   register: result
 - debug: msg='{{result.stdout_lines}}'
 
-- name: check NAT rules for source NAT
+- name: Check NAT rules for source NAT
   panos_match_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -145,7 +145,7 @@ EXAMPLES = '''
   register: result
 - debug: msg='{{result.stdout_lines}}'
 
-- name: check NAT rules for inbound web
+- name: Check NAT rules for inbound web
   panos_match_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -161,7 +161,7 @@ EXAMPLES = '''
   register: result
 - debug: msg='{{result.stdout_lines}}'
 
-- name: check security rules for outbound POP3 in vsys4
+- name: Check security rules for outbound POP3 in vsys4
   panos_match_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'

--- a/plugins/modules/network/panos/panos_mgtconfig.py
+++ b/plugins/modules/network/panos/panos_mgtconfig.py
@@ -56,7 +56,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: set dns and panorama
+- name: Set dns and panorama
   panos_mgtconfig:
     ip_address: "192.168.1.1"
     password: "admin"

--- a/plugins/modules/network/panos/panos_object.py
+++ b/plugins/modules/network/panos/panos_object.py
@@ -141,7 +141,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: search for shared address object
+- name: Search for shared address object
   panos_object:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -149,7 +149,7 @@ EXAMPLES = '''
     operation: 'find'
     address: 'DevNet'
 
-- name: create an address group in devicegroup using API key
+- name: Create an address group in devicegroup using API key
   panos_object:
     ip_address: '{{ ip_address }}'
     api_key: '{{ api_key }}'
@@ -160,7 +160,7 @@ EXAMPLES = '''
     tag_name: 'DMZ'
     devicegroup: 'DMZ Firewalls'
 
-- name: create a global service for TCP 3306
+- name: Create a global service for TCP 3306
   panos_object:
     ip_address: '{{ ip_address }}'
     api_key: '{{ api_key }}'
@@ -170,7 +170,7 @@ EXAMPLES = '''
     protocol: 'tcp'
     description: 'MySQL on tcp/3306'
 
-- name: create a global tag
+- name: Create a global tag
   panos_object:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -180,7 +180,7 @@ EXAMPLES = '''
     color: 'yellow'
     description: 'Associated with Project X'
 
-- name: delete an address object from a devicegroup using API key
+- name: Delete an address object from a devicegroup using API key
   panos_object:
     ip_address: '{{ ip_address }}'
     api_key: '{{ api_key }}'

--- a/plugins/modules/network/panos/panos_op.py
+++ b/plugins/modules/network/panos/panos_op.py
@@ -59,14 +59,14 @@ options:
 '''
 
 EXAMPLES = '''
-- name: show list of all interfaces
+- name: Show list of all interfaces
   panos_op:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
     password: '{{ password }}'
     cmd: 'show interfaces all'
 
-- name: show system info
+- name: Show system info
   panos_op:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'

--- a/plugins/modules/network/panos/panos_pg.py
+++ b/plugins/modules/network/panos/panos_pg.py
@@ -69,7 +69,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: setup security profile group
+- name: Setup security profile group
   panos_pg:
     ip_address: "192.168.1.1"
     password: "admin"

--- a/plugins/modules/network/panos/panos_query_rules.py
+++ b/plugins/modules/network/panos/panos_query_rules.py
@@ -92,7 +92,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: search for rules with tcp/3306
+- name: Search for rules with tcp/3306
   panos_query_rules:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -102,7 +102,7 @@ EXAMPLES = '''
     destination_port: '3306'
     protocol: 'tcp'
 
-- name: search devicegroup for inbound rules to dmz host
+- name: Search devicegroup for inbound rules to dmz host
   panos_query_rules:
     ip_address: '{{ ip_address }}'
     api_key: '{{ api_key }}'
@@ -110,7 +110,7 @@ EXAMPLES = '''
     destination_ip: '10.100.42.18'
     address: 'DeviceGroupA'
 
-- name: search for rules containing a specified rule tag
+- name: Search for rules containing a specified rule tag
   panos_query_rules:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'

--- a/plugins/modules/network/panos/panos_restart.py
+++ b/plugins/modules/network/panos/panos_restart.py
@@ -38,7 +38,8 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- panos_restart:
+- name: Restart a device
+  panos_restart:
     ip_address: "192.168.1.1"
     username: "admin"
     password: "admin"

--- a/plugins/modules/network/panos/panos_sag.py
+++ b/plugins/modules/network/panos/panos_sag.py
@@ -75,7 +75,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: sag
+- name: Sag
   panos_sag:
     ip_address: "192.168.1.1"
     password: "admin"

--- a/plugins/modules/network/panos/panos_security_rule.py
+++ b/plugins/modules/network/panos/panos_security_rule.py
@@ -155,7 +155,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: add an SSH inbound rule to devicegroup
+- name: Add an SSH inbound rule to devicegroup
   panos_security_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -176,7 +176,7 @@ EXAMPLES = '''
     action: 'allow'
     devicegroup: 'Cloud Edge'
 
-- name: add a rule to allow HTTP multimedia only from CDNs
+- name: Add a rule to allow HTTP multimedia only from CDNs
   panos_security_rule:
     ip_address: '10.5.172.91'
     username: 'admin'
@@ -195,7 +195,7 @@ EXAMPLES = '''
     hip_profiles: ['any']
     action: 'allow'
 
-- name: add a more complex rule that uses security profiles
+- name: Add a more complex rule that uses security profiles
   panos_security_rule:
     ip_address: '{{ ip_address }}'
     username: '{{ username }}'
@@ -211,7 +211,7 @@ EXAMPLES = '''
     url_filtering: 'default'
     wildfire_analysis: 'default'
 
-- name: delete a devicegroup security rule
+- name: Delete a devicegroup security rule
   panos_security_rule:
     ip_address: '{{ ip_address }}'
     api_key: '{{ api_key }}'
@@ -219,7 +219,7 @@ EXAMPLES = '''
     rule_name: 'Allow telnet'
     devicegroup: 'DC Firewalls'
 
-- name: find a specific security rule
+- name: Find a specific security rule
   panos_security_rule:
     ip_address: '{{ ip_address }}'
     password: '{{ password }}'

--- a/plugins/modules/network/radware/vdirect_commit.py
+++ b/plugins/modules/network/radware/vdirect_commit.py
@@ -110,7 +110,7 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: vdirect_commit
+- name: Commit
   vdirect_commit:
       vdirect_ip: 10.10.10.10
       vdirect_user: vDirect

--- a/plugins/modules/network/radware/vdirect_file.py
+++ b/plugins/modules/network/radware/vdirect_file.py
@@ -90,7 +90,7 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: vdirect_file
+- name: Upload a new or updates an existing runnable file
   vdirect_file:
       vdirect_ip: 10.10.10.10
       vdirect_user: vDirect

--- a/plugins/modules/network/radware/vdirect_runnable.py
+++ b/plugins/modules/network/radware/vdirect_runnable.py
@@ -103,7 +103,7 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: vdirect_runnable
+- name: Run the module from Ansible playbook
   vdirect_runnable:
       vdirect_ip: 10.10.10.10
       vdirect_user: vDirect

--- a/plugins/modules/network/routeros/routeros_command.py
+++ b/plugins/modules/network/routeros/routeros_command.py
@@ -59,22 +59,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run command on remote devices
+  - name: Run command on remote devices
     routeros_command:
       commands: /system routerboard print
 
-  - name: run command and check to see if output contains routeros
+  - name: Run command and check to see if output contains routeros
     routeros_command:
       commands: /system resource print
       wait_for: result[0] contains MikroTik
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     routeros_command:
       commands:
         - /system routerboard print
         - /system identity print
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     routeros_command:
       commands:
         - /system routerboard print

--- a/plugins/modules/network/routeros/routeros_facts.py
+++ b/plugins/modules/network/routeros/routeros_facts.py
@@ -30,17 +30,17 @@ options:
 '''
 
 EXAMPLES = """
-# Collect all facts from the device
-- routeros_facts:
+- name: Collect all facts from the device
+  routeros_facts:
     gather_subset: all
 
-# Collect only the config and default facts
-- routeros_facts:
+- name: Collect only the config and default facts
+  routeros_facts:
     gather_subset:
       - config
 
-# Do not collect hardware facts
-- routeros_facts:
+- name: Do not collect hardware facts
+  routeros_facts:
     gather_subset:
       - "!hardware"
 """

--- a/plugins/modules/network/slxos/slxos_command.py
+++ b/plugins/modules/network/slxos/slxos_command.py
@@ -64,22 +64,22 @@ options:
 
 EXAMPLES = """
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     slxos_command:
       commands: show version
 
-  - name: run show version and check to see if output contains SLX
+  - name: Run show version and check to see if output contains SLX
     slxos_command:
       commands: show version
       wait_for: result[0] contains SLX
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     slxos_command:
       commands:
         - show version
         - show interfaces
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     slxos_command:
       commands:
         - show version
@@ -87,7 +87,7 @@ tasks:
       wait_for:
         - result[0] contains SLX
         - result[1] contains Eth
-  - name: run command that requires answering a prompt
+  - name: Run command that requires answering a prompt
     slxos_command:
       commands:
         - command: 'clear sessions'

--- a/plugins/modules/network/slxos/slxos_config.py
+++ b/plugins/modules/network/slxos/slxos_config.py
@@ -174,18 +174,18 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure top level configuration
+- name: Configure top level configuration
   slxos_config:
     lines: hostname {{ inventory_hostname }}
 
-- name: configure interface settings
+- name: Configure interface settings
   slxos_config:
     lines:
       - description test interface
       - ip address 172.31.1.1/24
     parents: interface Ethernet 0/1
 
-- name: configure multiple interfaces
+- name: Configure multiple interfaces
   slxos_config:
     lines:
       - lacp timeout long
@@ -194,7 +194,7 @@ EXAMPLES = """
     - interface Ethernet 0/1
     - interface Ethernet 0/2
 
-- name: load new acl into device
+- name: Load new acl into device
   slxos_config:
     lines:
       - seq 10 permit ip host 1.1.1.1 any log
@@ -206,22 +206,22 @@ EXAMPLES = """
     before: no ip access-list extended test
     match: exact
 
-- name: check the running-config against master config
+- name: Check the running-config against master config
   slxos_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
-- name: check the startup-config against the running-config
+- name: Check the startup-config against the running-config
   slxos_config:
     diff_against: startup
     diff_ignore_lines:
       - ntp clock .*
 
-- name: save running to startup when modified
+- name: Save running to startup when modified
   slxos_config:
     save_when: modified
 
-- name: configurable backup path
+- name: Configurable backup path
   slxos_config:
     lines: hostname {{ inventory_hostname }}
     backup: yes

--- a/plugins/modules/network/slxos/slxos_facts.py
+++ b/plugins/modules/network/slxos/slxos_facts.py
@@ -48,17 +48,17 @@ options:
 '''
 
 EXAMPLES = """
-# Collect all facts from the device
-- slxos_facts:
+- name: Collect all facts from the device
+  slxos_facts:
     gather_subset: all
 
-# Collect only the config and default facts
-- slxos_facts:
+- name: Collect only the config and default facts
+  slxos_facts:
     gather_subset:
       - config
 
-# Do not collect hardware facts
-- slxos_facts:
+- name: Do not collect hardware facts
+  slxos_facts:
     gather_subset:
       - "!hardware"
 """

--- a/plugins/modules/network/slxos/slxos_interface.py
+++ b/plugins/modules/network/slxos/slxos_interface.py
@@ -84,24 +84,24 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure interface
+- name: Configure interface
   slxos_interface:
       name: Ethernet 0/2
       description: test-interface
       speed: 1000
       mtu: 9216
 
-- name: remove interface
+- name: Remove interface
   slxos_interface:
     name: Loopback 9
     state: absent
 
-- name: make interface up
+- name: Make interface up
   slxos_interface:
     name: Ethernet 0/2
     enabled: True
 
-- name: make interface down
+- name: Make interface down
   slxos_interface:
     name: Ethernet 0/2
     enabled: False

--- a/plugins/modules/network/slxos/slxos_linkagg.py
+++ b/plugins/modules/network/slxos/slxos_linkagg.py
@@ -56,17 +56,17 @@ options:
 '''
 
 EXAMPLES = """
-- name: create link aggregation group
+- name: Create link aggregation group
   slxos_linkagg:
     group: 10
     state: present
 
-- name: delete link aggregation group
+- name: Delete link aggregation group
   slxos_linkagg:
     group: 10
     state: absent
 
-- name: set link aggregation group to members
+- name: Set link aggregation group to members
   slxos_linkagg:
     group: 200
     mode: active
@@ -74,7 +74,7 @@ EXAMPLES = """
       - Ethernet 0/1
       - Ethernet 0/2
 
-- name: remove link aggregation group from Ethernet 0/1
+- name: Remove link aggregation group from Ethernet 0/1
   slxos_linkagg:
     group: 200
     mode: active

--- a/plugins/modules/network/sros/sros_command.py
+++ b/plugins/modules/network/sros/sros_command.py
@@ -78,25 +78,25 @@ vars:
 
 ---
 tasks:
-  - name: run show version on remote devices
+  - name: Run show version on remote devices
     sros_command:
       commands: show version
       provider: "{{ cli }}"
 
-  - name: run show version and check to see if output contains sros
+  - name: Run show version and check to see if output contains sros
     sros_command:
       commands: show version
       wait_for: result[0] contains sros
       provider: "{{ cli }}"
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     sros_command:
       commands:
         - show version
         - show port detail
       provider: "{{ cli }}"
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     sros_command:
       commands:
         - show version

--- a/plugins/modules/network/sros/sros_config.py
+++ b/plugins/modules/network/sros/sros_config.py
@@ -152,18 +152,18 @@ vars:
     transport: cli
 
 ---
-- name: enable rollback location
+- name: Enable rollback location
   sros_config:
     lines: configure system rollback rollback-location "cf3:/ansible"
     provider: "{{ cli }}"
 
-- name: set system name to {{ inventory_hostname }} using one line
+- name: Set system name to {{ inventory_hostname }} using one line
   sros_config:
     lines:
         - configure system name "{{ inventory_hostname }}"
     provider: "{{ cli }}"
 
-- name: set system name to {{ inventory_hostname }} using parents
+- name: Set system name to {{ inventory_hostname }} using parents
   sros_config:
     lines:
         - 'name "{{ inventory_hostname }}"'
@@ -173,13 +173,13 @@ vars:
     provider: "{{ cli }}"
     backup: yes
 
-- name: load config from file
+- name: Load config from file
   sros_config:
       src: "{{ inventory_hostname }}.cfg"
       provider: "{{ cli }}"
       save: yes
 
-- name: invalid use of lines
+- name: Invalid use of lines
   sros_config:
     lines:
       - service
@@ -187,7 +187,7 @@ vars:
       -         description "invalid lines example"
     provider: "{{ cli }}"
 
-- name: valid use of lines
+- name: Valid use of lines
   sros_config:
     lines:
       - description "invalid lines example"
@@ -196,7 +196,7 @@ vars:
       - vpls 1000 customer foo 1 create
     provider: "{{ cli }}"
 
-- name: configurable backup path
+- name: Configurable backup path
   sros_config:
     backup: yes
     backup_options:

--- a/plugins/modules/network/sros/sros_rollback.py
+++ b/plugins/modules/network/sros/sros_rollback.py
@@ -67,12 +67,12 @@ vars:
     transport: cli
 
 ---
-- name: configure rollback location
+- name: Configure rollback location
   sros_rollback:
     rollback_location: "cb3:/ansible"
     provider: "{{ cli }}"
 
-- name: remove all rollback configuration
+- name: Remove all rollback configuration
   sros_rollback:
     state: absent
     provider: "{{ cli }}"

--- a/plugins/modules/network/voss/voss_command.py
+++ b/plugins/modules/network/voss/voss_command.py
@@ -81,22 +81,22 @@ options:
 
 EXAMPLES = r"""
 tasks:
-  - name: run show sys software on remote devices
+  - name: Run show sys software on remote devices
     voss_command:
       commands: show sys software
 
-  - name: run show sys software and check to see if output contains VOSS
+  - name: Run show sys software and check to see if output contains VOSS
     voss_command:
       commands: show sys software
       wait_for: result[0] contains VOSS
 
-  - name: run multiple commands on remote nodes
+  - name: Run multiple commands on remote nodes
     voss_command:
       commands:
         - show sys software
         - show interfaces vlan
 
-  - name: run multiple commands and evaluate the output
+  - name: Run multiple commands and evaluate the output
     voss_command:
       commands:
         - show sys software
@@ -105,7 +105,7 @@ tasks:
         - result[0] contains Version
         - result[1] contains Basic
 
-  - name: run command that requires answering a prompt
+  - name: Run command that requires answering a prompt
     voss_command:
       commands:
         - command: 'reset'

--- a/plugins/modules/network/voss/voss_config.py
+++ b/plugins/modules/network/voss/voss_config.py
@@ -169,33 +169,33 @@ options:
 '''
 
 EXAMPLES = """
-- name: configure system name
+- name: Configure system name
   voss_config:
     lines: prompt "{{ inventory_hostname }}"
 
-- name: configure interface settings
+- name: Configure interface settings
   voss_config:
     lines:
       - name "ServerA"
     backup: yes
     parents: interface GigabitEthernet 1/1
 
-- name: check the running-config against master config
+- name: Check the running-config against master config
   voss_config:
     diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
-- name: check the startup-config against the running-config
+- name: Check the startup-config against the running-config
   voss_config:
     diff_against: startup
     diff_ignore_lines:
       - qos queue-profile .*
 
-- name: save running to startup when modified
+- name: Save running to startup when modified
   voss_config:
     save_when: modified
 
-- name: configurable backup path
+- name: Configurable backup path
   voss_config:
     backup: yes
     backup_options:

--- a/plugins/modules/network/voss/voss_facts.py
+++ b/plugins/modules/network/voss/voss_facts.py
@@ -47,17 +47,17 @@ options:
 '''
 
 EXAMPLES = """
-# Collect all facts from the device
-- voss_facts:
+- name: Collect all facts from the device
+  voss_facts:
     gather_subset: all
 
-# Collect only the config and default facts
-- voss_facts:
+- name: Collect only the config and default facts
+  voss_facts:
     gather_subset:
       - config
 
-# Do not collect hardware facts
-- voss_facts:
+- name: Do not collect hardware facts
+  voss_facts:
     gather_subset:
       - "!hardware"
 """


### PR DESCRIPTION
##### SUMMARY
https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#examples-block
```
Per playbook best practices, each example should include a name: line:
EXAMPLES = r'''
- name: Ensure foo is installed
  modulename:
    name: foo
    state: present
'''
The name: line should be capitalized and not include a trailing dot.
```

##### ISSUE TYPE
- Docs Pull Request
