### PR TITLE
Use pypi antsibull package

### DIFF
--- a/tests/sanity/extra/changelog.json
+++ b/tests/sanity/extra/changelog.json
@@ -8,6 +8,6 @@
         "changelogs/fragments/."
     ],
     "requirements": [
-        "git+git://github.com/ansible-community/antsibull.git@pip-installable#egg=antsibull"
+        "antsibull"
     ]
 }


### PR DESCRIPTION
##### SUMMARY
Use antsibull from pypi instead of installing it from git.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
