### PR TITLE
antsibull-changelog moved to its own repo

### DIFF
--- a/tests/sanity/extra/changelog.json
+++ b/tests/sanity/extra/changelog.json
@@ -8,6 +8,6 @@
         "changelogs/fragments/."
     ],
     "requirements": [
-        "antsibull"
+        "antsibull-changelog"
     ]
 }


### PR DESCRIPTION
##### SUMMARY
antsibull-changelog moved from https://github.com/ansible-community/antsibull/ to https://github.com/ansible-community/antsibull-changelog/.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
