### PR TITLE
Ensure netscaler_nitro_request get_filtered uses all filters, fixes #48

### DIFF
--- a/changelogs/fragments/52-netscaler_nitro_request-use-all-filters.yaml
+++ b/changelogs/fragments/52-netscaler_nitro_request-use-all-filters.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - netscaler_nitro_request - use all filters for get_filtered instead of only the first one (https://github.com/ansible-collections/community.network/issues/48).

--- a/plugins/modules/network/netscaler/netscaler_nitro_request.py
+++ b/plugins/modules/network/netscaler/netscaler_nitro_request.py
@@ -642,10 +642,7 @@ class NitroAPICaller(object):
         if self._module.params['filter'] is None:
             self.fail_module(msg='NITRO filter is undefined.')
 
-        keys = list(self._module.params['filter'].keys())
-        filter_key = keys[0]
-        filter_value = self._module.params['filter'][filter_key]
-        filter_str = '%s:%s' % (filter_key, filter_value)
+        filter_str = ','.join('%s:%s' % (k, v) for k, v in self._module.params['filter'].items())
 
         url = '%s://%s/nitro/v1/config/%s?filter=%s' % (
             self._module.params['nitro_protocol'],


### PR DESCRIPTION
##### SUMMARY
Loop over all filters and combine them with `&`. Before this, only the first filter was used.
Won't do the urlencode in the python code for now, as that would create backwards incompatibility with existing plays ('double' urlencode, see the example in #48)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
netscaler_nitro_request
