### PR TITLE
Prevent edgeos_config from saving in check mode.

### DIFF
--- a/changelogs/fragments/prevent-edgeos_config-saving-in-check-mode.yaml
+++ b/changelogs/fragments/prevent-edgeos_config-saving-in-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - edgeos_config - fixed issue where config could be saved while in check mode (https://github.com/ansible-collections/community.network/pull/78)

--- a/changelogs/fragments/prevent-edgeos_config-saving-in-check-mode.yaml
+++ b/changelogs/fragments/prevent-edgeos_config-saving-in-check-mode.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - edgeos_config - fixed issue where config could be saved while in check mode (https://github.com/ansible-collections/community.network/pull/78)

--- a/changelogs/fragments/prevent-edgeos_config-saving-in-check-mode.yaml
+++ b/changelogs/fragments/prevent-edgeos_config-saving-in-check-mode.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - edgeos_config - fixed issue where config could be saved while in check mode (https://github.com/ansible-collections/community.network/pull/78)

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -302,7 +302,8 @@ def main():
     if module.params['save']:
         diff = run_commands(module, commands=['configure', 'compare saved'])[1]
         if diff != '[edit]':
-            run_commands(module, commands=['save'])
+            if not module.check_mode:
+                run_commands(module, commands=['save'])
             result['changed'] = True
         run_commands(module, commands=['exit'])
 

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -303,7 +303,7 @@ def main():
         diff = run_commands(module, commands=['configure', 'compare saved'])[1]
         if diff != '[edit]':
             if not module.check_mode:
-              run_commands(module, commands=['save'])
+                run_commands(module, commands=['save'])
             result['changed'] = True
         run_commands(module, commands=['exit'])
 

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -302,7 +302,8 @@ def main():
     if module.params['save']:
         diff = run_commands(module, commands=['configure', 'compare saved'])[1]
         if diff != '[edit]':
-            run_commands(module, commands=['save'])
+            if not module.check_mode:
+              run_commands(module, commands=['save'])
             result['changed'] = True
         run_commands(module, commands=['exit'])
 

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -302,8 +302,7 @@ def main():
     if module.params['save']:
         diff = run_commands(module, commands=['configure', 'compare saved'])[1]
         if diff != '[edit]':
-            if not module.check_mode:
-                run_commands(module, commands=['save'])
+            run_commands(module, commands=['save'])
             result['changed'] = True
         run_commands(module, commands=['exit'])
 


### PR DESCRIPTION
##### SUMMARY
This PR prevents configuration from being saved while running in check mode. This aligns edgeos_config's behaviour with other _config modules and with the intention of Ansible's check mode.

#### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
Examples of other _command modules which avoid saving in check mode.
https://github.com/ansible-collections/arista.eos/blob/master/plugins/modules/eos_config.py
https://github.com/ansible-collections/cisco.asa/blob/master/plugins/modules/asa_config.py
https://github.com/ansible-collections/cisco.ios/blob/master/plugins/modules/ios_config.py

