### PR TITLE
edgeos_facts and edgeos_config - show full config without less

### DIFF
--- a/changelogs/fragments/fix_edgeos_facts_and_edgeos_cli.yml
+++ b/changelogs/fragments/fix_edgeos_facts_and_edgeos_cli.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - edgeos_facts - Added `cat` command to allow display of large files without `less`. Led to a timeout error. (https://github.com/ansible-collections/community.network/issues/79)
+  - edgeos_config - Added `cat` command to allow display of large files without `less`. Led to a timeout error. (https://github.com/ansible-collections/community.network/issues/79)

--- a/plugins/cliconf/edgeos.py
+++ b/plugins/cliconf/edgeos.py
@@ -49,7 +49,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     def get_config(self, source='running', format='text', flags=None):
-        return self.send_command('show configuration commands')
+        return self.send_command('show configuration commands|cat')
 
     def edit_config(self, candidate=None, commit=True, replace=False, comment=None):
         for cmd in chain(['configure'], to_list(candidate)):

--- a/plugins/modules/network/edgeos/edgeos_facts.py
+++ b/plugins/modules/network/edgeos/edgeos_facts.py
@@ -140,7 +140,7 @@ class Default(FactsBase):
 class Config(FactsBase):
 
     COMMANDS = [
-        'show configuration commands',
+        'show configuration commands|cat',
         'show system commit',
     ]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #79 

Somewhere the implementation for the `show configuration commands` seems to have changed (either on ansible side or with one of the newer EdgeOS Updates). This issue is persistent across EdgeOS 2.0.8 as well as EdgeOS 1.10.5 (the earliest version I could get for the Edgerouter 12). 

Maybe somebody could check with another router and version to verify compatibility?

Extended the command used to dump the config with a simple `|cat`. Now config gets dumped without `less`.

I'm not entirely sure if this sort of workaround is the right way but I'd be happy for feedback :)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`edgeos_config`
`edgeos_facts`
##### ADDITIONAL INFORMATION
See #79 for further information on my way of troubleshooting and ideas
