### PR TITLE
Fix unit tests

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,7 +1,7 @@
 unittest2 ; python_version <= '2.6'
 
 # requirements for ftd module_utils
-firepower-kickstart ; python_version >= '3.6'  # Python 3.6+ only
+firepower-kickstart ; python_version >= '3.6' and python_version < '3.9'  # Python 3.6+ only; dependency does not work with 3.9 yet
 
 # requirements for FortiManager modules
 pyFMG

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,7 +1,7 @@
 unittest2 ; python_version <= '2.6'
 
 # requirements for ftd module_utils
-firepower-kickstart ; python_version >= '3.5' and python_version < '3.9'  # Python 3 only; dependency does not work with 3.9 yet
+firepower-kickstart ; python_version >= '3.6'  # Python 3.6+ only
 
 # requirements for FortiManager modules
 pyFMG


### PR DESCRIPTION
##### SUMMARY
Apparently firepower-kickstart (or one of its dependencies) dropped 3.5 support, which makes the 3.5 unit tests fail.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
