### PR TITLE
nclu: Add support for check_mode and --diff

### DIFF
--- a/103-nclu-check-diff.yaml
+++ b/103-nclu-check-diff.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nclu - add support for check_mode and --diff

--- a/103-nclu-check-diff.yaml
+++ b/103-nclu-check-diff.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nclu - add support for check_mode and --diff
+  - nclu - add support for ``check_mode`` and ``--diff`` (https://github.com/ansible-collections/community.network/pull/103).

--- a/plugins/modules/network/cumulus/nclu.py
+++ b/plugins/modules/network/cumulus/nclu.py
@@ -52,6 +52,8 @@ options:
             - Commit description that will be recorded to the commit log if
               I(commit) or I(atomic) are true.
         default: "Ansible-originated commit"
+notes:
+    - Supports check_mode. Note that when using check_mode, I(abort) is always true.
 '''
 
 EXAMPLES = '''
@@ -203,14 +205,19 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
     output = "\n".join(output_lines)
 
     # If pending changes changed, report a change.
+    diff = {}
     after = check_pending(module)
     if before == after:
         _changed = False
     else:
         _changed = True
+        diff = {"prepared": after}
+
+    if module.check_mode:
+        command_helper(module, "abort")
 
     # Do the commit.
-    if (do_commit and _changed):
+    if (do_commit and _changed and not module.check_mode):
         result = command_helper(module, "commit description '%s'" % description)
         if "commit ignored" in result:
             _changed = False
@@ -220,7 +227,7 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
     elif do_abort:
         command_helper(module, "abort")
 
-    return _changed, output
+    return _changed, output, diff
 
 
 def main(testing=False):
@@ -231,6 +238,7 @@ def main(testing=False):
         abort=dict(required=False, type='bool', default=False),
         commit=dict(required=False, type='bool', default=False),
         atomic=dict(required=False, type='bool', default=False)),
+        supports_check_mode=True,
         mutually_exclusive=[('commands', 'template'),
                             ('commit', 'atomic'),
                             ('abort', 'atomic')]
@@ -242,9 +250,18 @@ def main(testing=False):
     abort = module.params.get('abort')
     description = module.params.get('description')
 
-    _changed, output = run_nclu(module, command_list, command_string, commit, atomic, abort, description)
+    if module.check_mode:
+        commit = False
+
+    _changed, output, diff = run_nclu(module, command_list, command_string, commit, atomic, abort, description)
+    result = {
+        "changed": _changed,
+        "msg": output,
+        "diff": diff
+    }
+
     if not testing:
-        module.exit_json(changed=_changed, msg=output)
+        module.exit_json(**result)
     elif testing:
         return {"changed": _changed, "msg": output}
 

--- a/tests/unit/plugins/modules/network/cumulus/test_nclu.py
+++ b/tests/unit/plugins/modules/network/cumulus/test_nclu.py
@@ -95,6 +95,7 @@ class FakeModule(object):
         self.last_commit = ""
         self.check_mode = False
 
+
 def skipUnlessNcluInstalled(original_function):
     if os.path.isfile('/usr/bin/net'):
         return original_function


### PR DESCRIPTION
##### SUMMARY

Adds support for `check_mode` and `--diff`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

nclu

##### ADDITIONAL INFORMATION

Example:

```
$ ansible-playbook --check --diff test.yml

PLAY [spine] *************************************************************************************************************************************************************************************************************************

TASK [nclu] **************************************************************************************************************************************************************************************************************************
--- /etc/network/interfaces	2019-11-11 11:03:27.483081304 -0800
+++ /run/nclu/ifupdown2/interfaces.tmp	2019-11-11 11:03:37.828080895 -0800
@@ -5,20 +5,23 @@
 ###############

 auto lo
 iface lo inet loopback
     address 10.10.10.101/32

 ###############
 # Mgmt interface
 ###############

+auto swp1
+iface swp1
+
 auto mgmt
 iface mgmt
     vrf-table auto
     address 127.0.0.1/8

 auto eth0
 iface eth0 inet dhcp
     vrf mgmt
 ###############
 # Fabric Links



net add/del commands since the last "net commit"
================================================

User     Timestamp                   Command
-------  --------------------------  ----------------------
cumulus  2019-11-11 11:03:37.764682  net add interface swp1

changed: [spine01]

PLAY RECAP ***************************************************************************************************************************************************************************************************************************
spine01                    : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

(migrated from https://github.com/ansible/ansible/pull/64677)