### PR TITLE
Fix exos_config:save_when when a stopped process is present

### DIFF
--- a/changelogs/fragments/110-fix-exos-save-config.yaml
+++ b/changelogs/fragments/110-fix-exos-save-config.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - exos_config - fix a hang due to an unexpected prompt during save_when (https://github.com/ansible-collections/community.network/pull/110).

--- a/plugins/modules/network/exos/exos_config.py
+++ b/plugins/modules/network/exos/exos_config.py
@@ -265,7 +265,7 @@ def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
         command = {"command": "save configuration",
-                   "prompt": "Do you want to save configuration", "answer": "y"}
+                   "prompt": ["Do you want to save configuration", "Do you want to continue"], "answer": "y"}
         run_commands(module, command)
     else:
         module.warn('Skipping command `save configuration` '


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

NOTE: This is distinct from Bug #109, which I filed earler!

When a stopped process exists on the Switch, the prompt for the `save` command changes. This trips up `save_when`, which does not recognize the prompt and it runs into a timeout. 

commit message:

>When a process is created, and then terminated but not deleted, the
>save config prompt will change. This module expected the old prompt,
>which never arrived, so the save will run into a timeout.
>
>This is how the special prompt looks:
>> * Slot-1 HOSTNAMEHERE.1 # save
>> The configuration file primary.cfg already exists.
>> Some process has been terminated/stopped. If you save the configuration
>> then that process's configuration will be lost.
>> Do you want to continue? (y/N)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`exos_config`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- hosts: all
  connection: network_cli
  user: uedvt359
  vars: 
    ansible_network_os: exos
    
  tasks:
  - name: create a process and make sure it was started at least once
    exos_config: 
      commands:
      - create process testProcess python-module __future__ start on-demand vr VR-Mgmt
      - start process testProcess
      save_when: changed

  - name: stop the saved process
    exos_config: 
      commands:
      - terminate process testProcess forceful

  - name: this will fail, since the prompt is unexpected
    exos_config:
      save_when: always

```
