### PR TITLE
Fix sanity for plugins

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -353,4 +353,8 @@ plugin_routing:
         removal_version: 2.0.0
         warning_text: The onyx doc_fragments plugin has been moved to the mellanox.onyx collection
       redirect: mellanox.onyx.onyx
-  
+  netconf:
+    sros:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: see plugin documentation for details

--- a/plugins/cliconf/eric_eccli.py
+++ b/plugins/cliconf/eric_eccli.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 author: Ericsson IPOS OAM team
-cliconf: eccli
+cliconf: eric_eccli
 short_description: Use eccli cliconf to run command on Ericsson ECCLI platform
 description:
   - This eccli plugin provides low level abstraction APIs for

--- a/plugins/lookup/avi.py
+++ b/plugins/lookup/avi.py
@@ -30,14 +30,14 @@ extends_documentation_fragment:
 
 EXAMPLES = """
 # Lookup query for all the objects of a specific type.
-- ansible.builtin.debug: msg="{{ lookup('avi', avi_credentials=avi_credentials, obj_type='virtualservice') }}"
+- ansible.builtin.debug: msg="{{ lookup('community.network.avi', avi_credentials=avi_credentials, obj_type='virtualservice') }}"
 # Lookup query for an object with the given name and type.
-- ansible.builtin.debug: msg="{{ lookup('avi', avi_credentials=avi_credentials, obj_name='vs1', obj_type='virtualservice', wantlist=True) }}"
+- ansible.builtin.debug: msg="{{ lookup('community.network.avi', avi_credentials=avi_credentials, obj_name='vs1', obj_type='virtualservice', wantlist=True) }}"
 # Lookup query for an object with the given UUID and type.
-- ansible.builtin.debug: msg="{{ lookup('avi', obj_uuid='virtualservice-5c0e183a-690a-45d8-8d6f-88c30a52550d', obj_type='virtualservice') }}"
+- ansible.builtin.debug: msg="{{ lookup('community.network.avi', obj_uuid='virtualservice-5c0e183a-690a-45d8-8d6f-88c30a52550d', obj_type='virtualservice') }}"
 # We can replace lookup with query function to always the get the output as list.
 # This is helpful for looping.
-- ansible.builtin.debug: msg="{{ query('avi', obj_uuid='virtualservice-5c0e183a-690a-45d8-8d6f-88c30a52550d', obj_type='virtualservice') }}"
+- ansible.builtin.debug: msg="{{ query('community.network.avi', obj_uuid='virtualservice-5c0e183a-690a-45d8-8d6f-88c30a52550d', obj_type='virtualservice') }}"
 """
 
 RETURN = """

--- a/plugins/lookup/avi.py
+++ b/plugins/lookup/avi.py
@@ -1,10 +1,12 @@
-# python 3 headers, required if submitting to Ansible
+# Copyright (c) Sandeep Bandi <sandeepb@avinetworks.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
 lookup: avi
-author: Sandeep Bandi <sandeepb@avinetworks.com>
+author: Sandeep Bandi (@sabandi) <sandeepb@avinetworks.com>
 short_description: Look up ``Avi`` objects.
 description:
     - Given an object_type, fetch all the objects of that type or fetch


### PR DESCRIPTION
##### SUMMARY
Fix some errors found with ansible/ansible#71734.

The most important change is fixing the avi lookup plugin, merged in ansible/ansible#58667. It does **NOT** contain a GPL copyright header (and the author's GitHub name was missing). @sabandi (the plugin's author) and @Qalthos (who merged the PR): do I assume correctly that the code is licensed under GPL v3+, as it was merged to Ansible as a plugin which are all expected to be GPL v3+ licensed?

CC @gundalow

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/lookup/avi.py
plugins/cliconf/eric_eccli.py
meta/runtime.yml
