### PR TITLE
CI tests: add a note not to use tests as an example of writing roles

### DIFF
--- a/tests/integration/targets/ce_is_is_instance/tasks/main.yaml
+++ b/tests/integration/targets/ce_is_is_instance/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_is_is_interface/tasks/main.yaml
+++ b/tests/integration/targets/ce_is_is_interface/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_is_is_view/tasks/main.yaml
+++ b/tests/integration/targets/ce_is_is_view/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_lacp/tasks/main.yaml
+++ b/tests/integration/targets/ce_lacp/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_lldp/tasks/main.yaml
+++ b/tests/integration/targets/ce_lldp/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_lldp_interface/tasks/main.yaml
+++ b/tests/integration/targets/ce_lldp_interface/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_mdn_interface/tasks/main.yaml
+++ b/tests/integration/targets/ce_mdn_interface/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_multicast_global/tasks/main.yaml
+++ b/tests/integration/targets/ce_multicast_global/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_multicast_igmp_enable/tasks/main.yaml
+++ b/tests/integration/targets/ce_multicast_igmp_enable/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/ce_static_route_bfd/tasks/main.yaml
+++ b/tests/integration/targets/ce_static_route_bfd/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/tests/integration/targets/cnos_backup/tasks/main.yml
+++ b/tests/integration/targets/cnos_backup/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample config back up tasks
 ---
 

--- a/tests/integration/targets/cnos_banner/tasks/main.yaml
+++ b/tests/integration/targets/cnos_banner/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_bgp/tasks/main.yml
+++ b/tests/integration/targets/cnos_bgp/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 ## This contain sample BGP execution tasks
 ---
 - name: Test BGP  - neighbor

--- a/tests/integration/targets/cnos_command/tasks/main.yaml
+++ b/tests/integration/targets/cnos_command/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_conditional_command/tasks/main.yml
+++ b/tests/integration/targets/cnos_conditional_command/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample command execution tasks
 ---
 

--- a/tests/integration/targets/cnos_conditional_template/tasks/main.yml
+++ b/tests/integration/targets/cnos_conditional_template/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample conditional template execution tasks
 ---
 - name: Replace Config CLI command template with values

--- a/tests/integration/targets/cnos_config/tasks/main.yaml
+++ b/tests/integration/targets/cnos_config/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_facts/tasks/main.yml
+++ b/tests/integration/targets/cnos_facts/tasks/main.yml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_image/tasks/main.yml
+++ b/tests/integration/targets/cnos_image/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample Image download tasks
 ---
 

--- a/tests/integration/targets/cnos_interface/tasks/main.yaml
+++ b/tests/integration/targets/cnos_interface/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_l2_interface/tasks/main.yaml
+++ b/tests/integration/targets/cnos_l2_interface/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }
 #- block:
 #    - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_l3_interface/tasks/main.yaml
+++ b/tests/integration/targets/cnos_l3_interface/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_linkagg/tasks/main.yaml
+++ b/tests/integration/targets/cnos_linkagg/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_lldp/tasks/main.yaml
+++ b/tests/integration/targets/cnos_lldp/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_logging/tasks/main.yaml
+++ b/tests/integration/targets/cnos_logging/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_rollback/tasks/main.yml
+++ b/tests/integration/targets/cnos_rollback/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample config Roll Back execution tasks
 ---
 

--- a/tests/integration/targets/cnos_save/tasks/main.yml
+++ b/tests/integration/targets/cnos_save/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample template execution tasks
 ---
 - name: Test Save

--- a/tests/integration/targets/cnos_showrun/tasks/main.yml
+++ b/tests/integration/targets/cnos_showrun/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample show rnunning config tasks
 ---
 - name: Test Running Configurations

--- a/tests/integration/targets/cnos_static_route/tasks/main.yaml
+++ b/tests/integration/targets/cnos_static_route/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_system/tasks/main.yaml
+++ b/tests/integration/targets/cnos_system/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_template/tasks/main.yml
+++ b/tests/integration/targets/cnos_template/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample template execution tasks
 ---
 - name: Creates directory

--- a/tests/integration/targets/cnos_user/tasks/main.yaml
+++ b/tests/integration/targets/cnos_user/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_vlag/tasks/main.yml
+++ b/tests/integration/targets/cnos_vlag/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # This contain sample template execution tasks
 ---
 - name: Test Vlag  - enable

--- a/tests/integration/targets/cnos_vlan/tasks/main.yaml
+++ b/tests/integration/targets/cnos_vlan/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/cnos_vrf/tasks/main.yaml
+++ b/tests/integration/targets/cnos_vrf/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/enos_command/tasks/main.yaml
+++ b/tests/integration/targets/enos_command/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/enos_config/tasks/main.yaml
+++ b/tests/integration/targets/enos_config/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/enos_facts/tasks/main.yml
+++ b/tests/integration/targets/enos_facts/tasks/main.yml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/tests/integration/targets/exos_command/tasks/main.yaml
+++ b/tests/integration/targets/exos_command/tasks/main.yaml
@@ -1,3 +1,8 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - {include: cli.yaml, tags: ['cli']}
 - {include: httpapi.yaml, tags: ['httpapi']}

--- a/tests/integration/targets/exos_config/tasks/main.yaml
+++ b/tests/integration/targets/exos_config/tasks/main.yaml
@@ -1,3 +1,8 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - {include: cli.yaml, tags: ['cli']}
 - {include: httpapi.yaml, tags: ['httpapi']}

--- a/tests/integration/targets/exos_facts/tasks/main.yaml
+++ b/tests/integration/targets/exos_facts/tasks/main.yaml
@@ -1,3 +1,8 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - {include: cli.yaml, tags: ['cli']}
 - {include: httpapi.yaml, tags: ['httpapi']}

--- a/tests/integration/targets/exos_l2_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/exos_l2_interfaces/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: httpapi.yaml, tags: ['httpapi'] }

--- a/tests/integration/targets/exos_lldp_global/tasks/main.yaml
+++ b/tests/integration/targets/exos_lldp_global/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: httpapi.yaml, tags: ['httpapi'] }

--- a/tests/integration/targets/exos_lldp_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/exos_lldp_interfaces/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: httpapi.yaml, tags: ['httpapi'] }

--- a/tests/integration/targets/exos_vlans/tasks/main.yaml
+++ b/tests/integration/targets/exos_vlans/tasks/main.yaml
@@ -1,2 +1,7 @@
 ---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - { include: httpapi.yaml, tags: ['httpapi'] }

--- a/tests/integration/targets/nuage_vspk/tasks/main.yml
+++ b/tests/integration/targets/nuage_vspk/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
     - name: run test case
       include: "{{ test_case_to_run }}"

--- a/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
     - name: Install Nuage VSD API Simulator
       pip:


### PR DESCRIPTION
##### SUMMARY
CI tests: add a note not to use tests as an example of writing roles because the tests are included in release tarballs (we discussed this at Community meeting yesterday)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
CI tests
