### PR TITLE
Allow network_cli type for platforms using persistent connection

### DIFF
--- a/changelogs/fragments/119_fix_connection_check_issue.yml
+++ b/changelogs/fragments/119_fix_connection_check_issue.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+- Add check for network_cli connection type in action plugins
+
+deprecated_features:
+- Deprecate connection=local support for network platforms using persistent framework

--- a/changelogs/fragments/119_fix_connection_check_issue.yml
+++ b/changelogs/fragments/119_fix_connection_check_issue.yml
@@ -1,6 +1,6 @@
 ---
 bugfixes:
-- Add check for network_cli connection type in action plugins
+- action pugins - add check for network_cli connection type (https://github.com/ansible-collections/community.network/issues/119, https://github.com/ansible-collections/community.network/pull/120).
 
 deprecated_features:
-- Deprecate connection=local support for network platforms using persistent framework
+- Deprecate connection=local support for network platforms using persistent framework (https://github.com/ansible-collections/community.network/pull/120).

--- a/plugins/action/aireos.py
+++ b/plugins/action/aireos.py
@@ -73,7 +73,7 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
             msg = "connection local support for this module is deprecated use either" \
                   " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-            deprecate(msg, version='4.0.0', collection_name='community.network')
+            display.deprecated(msg, version='4.0.0', collection_name='community.network')
 
         else:
             return dict(

--- a/plugins/action/aireos.py
+++ b/plugins/action/aireos.py
@@ -37,43 +37,61 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         module_name = self._task.action.split('.')[-1]
+
         self._config_module = True if module_name == 'aireos_config' else False
 
-        if self._play_context.connection != 'local':
+        persistent_connection = self._play_context.connection.split('.')[-1]
+        warnings = []
+
+        if persistent_connection == 'network_cli':
+            provider = self._task.args.get('provider', {})
+            if any(provider.values()):
+                display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
+        elif self._play_context.connection == 'local':
+            provider = load_provider(aireos_provider_spec, self._task.args)
+            pc = copy.deepcopy(self._play_context)
+            pc.connection = 'network_cli'
+            pc.network_os = 'aireos'
+            pc.remote_addr = provider['host'] or self._play_context.remote_addr
+            pc.port = int(provider['port'] or self._play_context.port or 22)
+            pc.remote_user = provider['username'] or self._play_context.connection_user
+            pc.password = provider['password'] or self._play_context.password
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
+                                                                       task_uuid=self._task._uuid)
+
+            display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
+            socket_path = connection.run()
+            display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+            if not socket_path:
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+            task_vars['ansible_socket'] = socket_path
+            warnings.append(['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
+                             ' use connection %s' % pc.connection])
+
+        else:
             return dict(
                 failed=True,
-                msg='invalid connection specified, expected connection=local, '
+                msg='invalid connection specified, expected connection is either network_cli or ansible.netcommon.network_cli'
                     'got %s' % self._play_context.connection
             )
 
-        provider = load_provider(aireos_provider_spec, self._task.args)
-
-        pc = copy.deepcopy(self._play_context)
-        pc.connection = 'network_cli'
-        pc.network_os = 'aireos'
-        pc.remote_addr = provider['host'] or self._play_context.remote_addr
-        pc.port = int(provider['port'] or self._play_context.port or 22)
-        pc.remote_user = provider['username'] or self._play_context.connection_user
-        pc.password = provider['password'] or self._play_context.password
-        command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
-
-        display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
-        connection.set_options(direct={'persistent_command_timeout': command_timeout})
-
-        socket_path = connection.run()
-        display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
-        if not socket_path:
-            return {'failed': True,
-                    'msg': 'unable to open shell. Please see: ' +
-                           'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
-
-        task_vars['ansible_socket'] = socket_path
-
-        if self._play_context.become_method == 'enable':
+        if self._play_context.become_method and self._play_context.become_method.split('.')[-1] == 'enable':
             self._play_context.become = False
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(task_vars=task_vars)
+        if warnings:
+            if 'warnings' in result:
+                result['warnings'].extend(warnings)
+            else:
+                result['warnings'] = warnings
 
         return result

--- a/plugins/action/aireos.py
+++ b/plugins/action/aireos.py
@@ -38,11 +38,8 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         module_name = self._task.action.split('.')[-1]
-
         self._config_module = True if module_name == 'aireos_config' else False
-
         persistent_connection = self._play_context.connection.split('.')[-1]
-        warnings = []
 
         if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})

--- a/plugins/action/aireos.py
+++ b/plugins/action/aireos.py
@@ -25,6 +25,7 @@ import copy
 from ansible import constants as C
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible_collections.community.network.plugins.module_utils.network.aireos.aireos import aireos_provider_spec
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible.utils.display import Display
 
@@ -73,8 +74,9 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-            warnings.append(['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                             ' use connection %s' % pc.connection])
+            msg = "connection local support for this module is deprecated use either" \
+                  " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+            deprecate(msg, version='4.0.0', collection_name='community.network')
 
         else:
             return dict(
@@ -88,10 +90,4 @@ class ActionModule(ActionNetworkModule):
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
-
         return result

--- a/plugins/action/aruba.py
+++ b/plugins/action/aruba.py
@@ -40,7 +40,6 @@ class ActionModule(ActionNetworkModule):
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'aruba_config' else False
         persistent_connection = self._play_context.connection.split('.')[-1]
-        warnings = []
 
         if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})

--- a/plugins/action/aruba.py
+++ b/plugins/action/aruba.py
@@ -73,7 +73,7 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
             msg = "connection local support for this module is deprecated use either" \
                   " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-            deprecate(msg, version='4.0.0', collection_name='community.network')
+            display.deprecated(msg, version='4.0.0', collection_name='community.network')
         else:
             return dict(
                 failed=True,

--- a/plugins/action/aruba.py
+++ b/plugins/action/aruba.py
@@ -38,42 +38,58 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'aruba_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
+        warnings = []
 
-        if self._play_context.connection != 'local':
+        if persistent_connection == 'network_cli':
+            provider = self._task.args.get('provider', {})
+            if any(provider.values()):
+                display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
+        elif self._play_context.connection == 'local':
+            provider = load_provider(aruba_provider_spec, self._task.args)
+            pc = copy.deepcopy(self._play_context)
+            pc.connection = 'network_cli'
+            pc.network_os = 'aruba'
+            pc.remote_addr = provider['host'] or self._play_context.remote_addr
+            pc.port = int(provider['port'] or self._play_context.port or 22)
+            pc.remote_user = provider['username'] or self._play_context.connection_user
+            pc.password = provider['password'] or self._play_context.password
+            pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+            command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
+                                                                   task_uuid=self._task._uuid)
+
+            display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
+            socket_path = connection.run()
+            display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+            if not socket_path:
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+            task_vars['ansible_socket'] = socket_path
+            warnings.append(['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
+                             ' use connection %s' % pc.connection])
+        else:
             return dict(
                 failed=True,
-                msg='invalid connection specified, expected connection=local, '
+                msg='invalid connection specified, expected connection is either network_cli or ansible.netcommon.network_cli'
                     'got %s' % self._play_context.connection
             )
 
-        provider = load_provider(aruba_provider_spec, self._task.args)
-
-        pc = copy.deepcopy(self._play_context)
-        pc.connection = 'network_cli'
-        pc.network_os = 'aruba'
-        pc.remote_addr = provider['host'] or self._play_context.remote_addr
-        pc.port = int(provider['port'] or self._play_context.port or 22)
-        pc.remote_user = provider['username'] or self._play_context.connection_user
-        pc.password = provider['password'] or self._play_context.password
-        pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
-        command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
-
-        display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
-        connection.set_options(direct={'persistent_command_timeout': command_timeout})
-
-        socket_path = connection.run()
-        display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
-        if not socket_path:
-            return {'failed': True,
-                    'msg': 'unable to open shell. Please see: ' +
-                           'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
-
-        task_vars['ansible_socket'] = socket_path
-
-        if self._play_context.become_method == 'enable':
+        if self._play_context.become_method and self._play_context.become_method.split('.')[-1] == 'enable':
             self._play_context.become = False
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(task_vars=task_vars)
+        if warnings:
+            if 'warnings' in result:
+                result['warnings'].extend(warnings)
+            else:
+                result['warnings'] = warnings
+
         return result

--- a/plugins/action/aruba.py
+++ b/plugins/action/aruba.py
@@ -25,6 +25,7 @@ import copy
 from ansible import constants as C
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible_collections.community.network.plugins.module_utils.network.aruba.aruba import aruba_provider_spec
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible.utils.display import Display
 
@@ -58,8 +59,7 @@ class ActionModule(ActionNetworkModule):
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
             command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
-                                                                   task_uuid=self._task._uuid)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
@@ -72,8 +72,9 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-            warnings.append(['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                             ' use connection %s' % pc.connection])
+            msg = "connection local support for this module is deprecated use either" \
+                  " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+            deprecate(msg, version='4.0.0', collection_name='community.network')
         else:
             return dict(
                 failed=True,
@@ -86,10 +87,4 @@ class ActionModule(ActionNetworkModule):
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
-
         return result

--- a/plugins/action/ce.py
+++ b/plugins/action/ce.py
@@ -78,7 +78,7 @@ class ActionModule(ActionNetworkModule):
                 self._task.args['provider'] = provider
                 msg = "connection local support for this module is deprecated use either" \
                       " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-                deprecate(msg, version='4.0.0', collection_name='community.network')
+                display.deprecated(msg, version='4.0.0', collection_name='community.network')
 
         elif persistent_connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})

--- a/plugins/action/ce.py
+++ b/plugins/action/ce.py
@@ -61,10 +61,8 @@ class ActionModule(ActionNetworkModule):
                 if module_name in ['ce_netconf'] or module_name not in CLI_SUPPORTED_MODULES:
                     pc.connection = 'netconf'
 
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
-                                                                           task_uuid=self._task._uuid)
-
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()
@@ -94,5 +92,4 @@ class ActionModule(ActionNetworkModule):
                         % (self._play_context.connection, self._task.action)}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-
         return result

--- a/plugins/action/ce.py
+++ b/plugins/action/ce.py
@@ -12,6 +12,7 @@ import copy
 from ansible import constants as C
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible_collections.community.network.plugins.module_utils.network.cloudengine.ce import ce_provider_spec
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible.utils.display import Display
 
@@ -78,9 +79,10 @@ class ActionModule(ActionNetworkModule):
                 # make sure a transport value is set in args
                 self._task.args['transport'] = transport
                 self._task.args['provider'] = provider
-                warnings.append(
-                    ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                     ' use connection %s' % pc.connection])
+                msg = "connection local support for this module is deprecated use either" \
+                      " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+                deprecate(msg, version='4.0.0', collection_name='community.network')
+
         elif persistent_connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
@@ -93,9 +95,5 @@ class ActionModule(ActionNetworkModule):
                         % (self._play_context.connection, self._task.action)}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
+
         return result

--- a/plugins/action/ce.py
+++ b/plugins/action/ce.py
@@ -36,7 +36,6 @@ class ActionModule(ActionNetworkModule):
         self._config_module = True if module_name == 'ce_config' else False
         socket_path = None
         persistent_connection = self._play_context.connection.split('.')[-1]
-        warnings = []
 
         if self._play_context.connection == 'local':
             provider = load_provider(ce_provider_spec, self._task.args)

--- a/plugins/action/ce.py
+++ b/plugins/action/ce.py
@@ -35,6 +35,7 @@ class ActionModule(ActionNetworkModule):
         self._config_module = True if module_name == 'ce_config' else False
         socket_path = None
         persistent_connection = self._play_context.connection.split('.')[-1]
+        warnings = []
 
         if self._play_context.connection == 'local':
             provider = load_provider(ce_provider_spec, self._task.args)
@@ -59,8 +60,11 @@ class ActionModule(ActionNetworkModule):
                 )
                 if module_name in ['ce_netconf'] or module_name not in CLI_SUPPORTED_MODULES:
                     pc.connection = 'netconf'
+
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
+                                                                           task_uuid=self._task._uuid)
+
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()
@@ -74,6 +78,9 @@ class ActionModule(ActionNetworkModule):
                 # make sure a transport value is set in args
                 self._task.args['transport'] = transport
                 self._task.args['provider'] = provider
+                warnings.append(
+                    ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
+                     ' use connection %s' % pc.connection])
         elif persistent_connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
@@ -86,4 +93,9 @@ class ActionModule(ActionNetworkModule):
                         % (self._play_context.connection, self._task.action)}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
+        if warnings:
+            if 'warnings' in result:
+                result['warnings'].extend(warnings)
+            else:
+                result['warnings'] = warnings
         return result

--- a/plugins/action/cnos.py
+++ b/plugins/action/cnos.py
@@ -58,10 +58,9 @@ class ActionModule(ActionNetworkModule):
             pc.become = provider['authorize'] or True
             pc.become_pass = provider['auth_pass']
             pc.become_method = 'enable'
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
-                                                                       task_uuid=self._task._uuid)
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
@@ -77,5 +76,4 @@ class ActionModule(ActionNetworkModule):
             deprecate(msg, version='4.0.0', collection_name='community.network')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-
         return result

--- a/plugins/action/cnos.py
+++ b/plugins/action/cnos.py
@@ -73,7 +73,7 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
             msg = "connection local support for this module is deprecated use either" \
                   " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-            deprecate(msg, version='4.0.0', collection_name='community.network')
+            display.deprecated(msg, version='4.0.0', collection_name='community.network')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/plugins/action/cnos.py
+++ b/plugins/action/cnos.py
@@ -36,8 +36,15 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'cnos_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
+        warnings = []
 
-        if self._play_context.connection == 'local':
+        if persistent_connection == 'network_cli':
+            provider = self._task.args.get('provider', {})
+            if any(provider.values()):
+                display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
+        elif self._play_context.connection == 'local':
             provider = load_provider(cnos_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)
             pc.connection = 'network_cli'
@@ -51,9 +58,10 @@ class ActionModule(ActionNetworkModule):
             pc.become = provider['authorize'] or True
             pc.become_pass = provider['auth_pass']
             pc.become_method = 'enable'
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin,
+                                                                       task_uuid=self._task._uuid)
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()
@@ -64,6 +72,14 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
+            warnings.append(
+                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
+                 ' use connection %s' % pc.connection])
 
         result = super(ActionModule, self).run(task_vars=task_vars)
+        if warnings:
+            if 'warnings' in result:
+                result['warnings'].extend(warnings)
+            else:
+                result['warnings'] = warnings
         return result

--- a/plugins/action/cnos.py
+++ b/plugins/action/cnos.py
@@ -38,7 +38,6 @@ class ActionModule(ActionNetworkModule):
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'cnos_config' else False
         persistent_connection = self._play_context.connection.split('.')[-1]
-        warnings = []
 
         if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})

--- a/plugins/action/cnos.py
+++ b/plugins/action/cnos.py
@@ -23,6 +23,7 @@ import copy
 from ansible import constants as C
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible_collections.community.network.plugins.module_utils.network.cnos.cnos import cnos_provider_spec
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible.utils.display import Display
 
@@ -72,14 +73,10 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-            warnings.append(
-                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                 ' use connection %s' % pc.connection])
+            msg = "connection local support for this module is deprecated use either" \
+                  " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+            deprecate(msg, version='4.0.0', collection_name='community.network')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
+
         return result

--- a/plugins/action/enos.py
+++ b/plugins/action/enos.py
@@ -73,7 +73,7 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
             msg = "connection local support for this module is deprecated use either" \
                   " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-            deprecate(msg, version='4.0.0', collection_name='community.network')
+            display.deprecated(msg, version='4.0.0', collection_name='community.network')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/plugins/action/enos.py
+++ b/plugins/action/enos.py
@@ -38,7 +38,6 @@ class ActionModule(ActionNetworkModule):
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'enos_config' else False
         persistent_connection = self._play_context.connection.split('.')[-1]
-        warnings = []
 
         if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})

--- a/plugins/action/enos.py
+++ b/plugins/action/enos.py
@@ -76,5 +76,4 @@ class ActionModule(ActionNetworkModule):
             deprecate(msg, version='4.0.0', collection_name='community.network')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-
         return result

--- a/plugins/action/enos.py
+++ b/plugins/action/enos.py
@@ -23,6 +23,7 @@ import copy
 from ansible import constants as C
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible_collections.community.network.plugins.module_utils.network.enos.enos import enos_provider_spec
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible.utils.display import Display
 
@@ -71,13 +72,10 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-            warnings.append(
-                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                 ' use connection %s' % pc.connection])
+            msg = "connection local support for this module is deprecated use either" \
+                  " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+            deprecate(msg, version='4.0.0', collection_name='community.network')
+
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
+
         return result

--- a/plugins/action/ironware.py
+++ b/plugins/action/ironware.py
@@ -35,7 +35,7 @@ class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
-        warnings = []
+
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'ironware_config' else False
         persistent_connection = self._play_context.connection.split('.')[-1]

--- a/plugins/action/ironware.py
+++ b/plugins/action/ironware.py
@@ -76,7 +76,7 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
             msg = "connection local support for this module is deprecated use either" \
                   " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-            deprecate(msg, version='4.0.0', collection_name='community.network')
+            display.deprecated(msg, version='4.0.0', collection_name='community.network')
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 

--- a/plugins/action/ironware.py
+++ b/plugins/action/ironware.py
@@ -23,6 +23,7 @@ import sys
 import copy
 
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible_collections.community.network.plugins.module_utils.network.ironware.ironware import ironware_provider_spec
 from ansible.utils.display import Display
@@ -73,16 +74,12 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-            warnings.append(
-                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                 ' use connection %s' % pc.connection])
+            msg = "connection local support for this module is deprecated use either" \
+                  " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+            deprecate(msg, version='4.0.0', collection_name='community.network')
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
+
         return result

--- a/plugins/action/ironware.py
+++ b/plugins/action/ironware.py
@@ -34,7 +34,7 @@ class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
-
+        warnings = []
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'ironware_config' else False
         persistent_connection = self._play_context.connection.split('.')[-1]
@@ -73,8 +73,16 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
+            warnings.append(
+                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
+                 ' use connection %s' % pc.connection])
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
+        if warnings:
+            if 'warnings' in result:
+                result['warnings'].extend(warnings)
+            else:
+                result['warnings'] = warnings
         return result

--- a/plugins/action/ironware.py
+++ b/plugins/action/ironware.py
@@ -81,5 +81,4 @@ class ActionModule(ActionNetworkModule):
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-
         return result

--- a/plugins/action/sros.py
+++ b/plugins/action/sros.py
@@ -78,5 +78,4 @@ class ActionModule(ActionNetworkModule):
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-
         return result

--- a/plugins/action/sros.py
+++ b/plugins/action/sros.py
@@ -73,7 +73,7 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
             msg = "connection local support for this module is deprecated use either" \
                   " 'network_cli' or 'ansible.netcommon.network_cli' connection"
-            deprecate(msg, version='4.0.0', collection_name='community.network')
+            display.deprecated(msg, version='4.0.0', collection_name='community.network')
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 

--- a/plugins/action/sros.py
+++ b/plugins/action/sros.py
@@ -35,7 +35,7 @@ class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
-
+        warnings = []
         module_name = self._task.action.split('.')[-1]
         persistent_connection = self._play_context.connection.split('.')[-1]
 
@@ -70,8 +70,16 @@ class ActionModule(ActionNetworkModule):
                         'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
+            warnings.append(
+                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
+                 ' use connection %s' % pc.connection])
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
+        if warnings:
+            if 'warnings' in result:
+                result['warnings'].extend(warnings)
+            else:
+                result['warnings'] = warnings
         return result

--- a/plugins/action/sros.py
+++ b/plugins/action/sros.py
@@ -36,11 +36,11 @@ class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
-        warnings = []
+
         module_name = self._task.action.split('.')[-1]
         persistent_connection = self._play_context.connection.split('.')[-1]
-
         self._config_module = True if module_name == 'sros_config' else False
+
         if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):

--- a/plugins/action/sros.py
+++ b/plugins/action/sros.py
@@ -25,6 +25,7 @@ import copy
 from ansible import constants as C
 from ansible_collections.ansible.netcommon.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible_collections.community.network.plugins.module_utils.network.sros.sros import sros_provider_spec
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.warnings import deprecate
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import load_provider
 from ansible.utils.display import Display
 
@@ -70,16 +71,12 @@ class ActionModule(ActionNetworkModule):
                         'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-            warnings.append(
-                ['connection local support for this module is deprecated and will be removed after date 2022-09-25,'
-                 ' use connection %s' % pc.connection])
+            msg = "connection local support for this module is deprecated use either" \
+                  " 'network_cli' or 'ansible.netcommon.network_cli' connection"
+            deprecate(msg, version='4.0.0', collection_name='community.network')
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
-        if warnings:
-            if 'warnings' in result:
-                result['warnings'].extend(warnings)
-            else:
-                result['warnings'] = warnings
+
         return result

--- a/plugins/module_utils/network/aireos/aireos.py
+++ b/plugins/module_utils/network/aireos/aireos.py
@@ -44,7 +44,8 @@ aireos_provider_spec = {
     'timeout': dict(type='int'),
 }
 aireos_argument_spec = {
-    'provider': dict(type='dict', options=aireos_provider_spec, removed_in_version='4.0.0')
+    'provider': dict(type='dict', options=aireos_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network')
 }
 
 aireos_top_spec = {

--- a/plugins/module_utils/network/aireos/aireos.py
+++ b/plugins/module_utils/network/aireos/aireos.py
@@ -44,7 +44,7 @@ aireos_provider_spec = {
     'timeout': dict(type='int'),
 }
 aireos_argument_spec = {
-    'provider': dict(type='dict', options=aireos_provider_spec, removed_at_date="2022-09-25")
+    'provider': dict(type='dict', options=aireos_provider_spec, removed_in_version='4.0.0')
 }
 
 aireos_top_spec = {

--- a/plugins/module_utils/network/aireos/aireos.py
+++ b/plugins/module_utils/network/aireos/aireos.py
@@ -44,7 +44,7 @@ aireos_provider_spec = {
     'timeout': dict(type='int'),
 }
 aireos_argument_spec = {
-    'provider': dict(type='dict', options=aireos_provider_spec)
+    'provider': dict(type='dict', options=aireos_provider_spec, removed_at_date="2022-09-25")
 }
 
 aireos_top_spec = {

--- a/plugins/module_utils/network/aruba/aruba.py
+++ b/plugins/module_utils/network/aruba/aruba.py
@@ -47,7 +47,7 @@ aruba_provider_spec = {
     'timeout': dict(type='int'),
 }
 aruba_argument_spec = {
-    'provider': dict(type='dict', options=aruba_provider_spec, removed_at_date="2022-09-25")
+    'provider': dict(type='dict', options=aruba_provider_spec, removed_in_version='4.0.0')
 }
 
 aruba_top_spec = {

--- a/plugins/module_utils/network/aruba/aruba.py
+++ b/plugins/module_utils/network/aruba/aruba.py
@@ -47,7 +47,8 @@ aruba_provider_spec = {
     'timeout': dict(type='int'),
 }
 aruba_argument_spec = {
-    'provider': dict(type='dict', options=aruba_provider_spec, removed_in_version='4.0.0')
+    'provider': dict(type='dict', options=aruba_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network')
 }
 
 aruba_top_spec = {

--- a/plugins/module_utils/network/aruba/aruba.py
+++ b/plugins/module_utils/network/aruba/aruba.py
@@ -47,7 +47,7 @@ aruba_provider_spec = {
     'timeout': dict(type='int'),
 }
 aruba_argument_spec = {
-    'provider': dict(type='dict', options=aruba_provider_spec)
+    'provider': dict(type='dict', options=aruba_provider_spec, removed_at_date="2022-09-25")
 }
 
 aruba_top_spec = {

--- a/plugins/module_utils/network/cloudengine/ce.py
+++ b/plugins/module_utils/network/cloudengine/ce.py
@@ -71,7 +71,7 @@ ce_provider_spec = {
     'transport': dict(default='cli', choices=['cli', 'netconf']),
 }
 ce_argument_spec = {
-    'provider': dict(type='dict', options=ce_provider_spec, removed_at_date="2022-09-25"),
+    'provider': dict(type='dict', options=ce_provider_spec, removed_in_version='4.0.0'),
 }
 
 

--- a/plugins/module_utils/network/cloudengine/ce.py
+++ b/plugins/module_utils/network/cloudengine/ce.py
@@ -71,7 +71,8 @@ ce_provider_spec = {
     'transport': dict(default='cli', choices=['cli', 'netconf']),
 }
 ce_argument_spec = {
-    'provider': dict(type='dict', options=ce_provider_spec, removed_in_version='4.0.0'),
+    'provider': dict(type='dict', options=ce_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network'),
 }
 
 

--- a/plugins/module_utils/network/cloudengine/ce.py
+++ b/plugins/module_utils/network/cloudengine/ce.py
@@ -71,7 +71,7 @@ ce_provider_spec = {
     'transport': dict(default='cli', choices=['cli', 'netconf']),
 }
 ce_argument_spec = {
-    'provider': dict(type='dict', options=ce_provider_spec),
+    'provider': dict(type='dict', options=ce_provider_spec, removed_at_date="2022-09-25"),
 }
 
 

--- a/plugins/module_utils/network/cnos/cnos.py
+++ b/plugins/module_utils/network/cnos/cnos.py
@@ -73,7 +73,7 @@ cnos_provider_spec = {
 }
 
 cnos_argument_spec = {
-    'provider': dict(type='dict', options=cnos_provider_spec),
+    'provider': dict(type='dict', options=cnos_provider_spec, removed_at_date="2022-09-25"),
 }
 
 command_spec = {

--- a/plugins/module_utils/network/cnos/cnos.py
+++ b/plugins/module_utils/network/cnos/cnos.py
@@ -73,7 +73,8 @@ cnos_provider_spec = {
 }
 
 cnos_argument_spec = {
-    'provider': dict(type='dict', options=cnos_provider_spec, removed_in_version='4.0.0'),
+    'provider': dict(type='dict', options=cnos_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network'),
 }
 
 command_spec = {

--- a/plugins/module_utils/network/cnos/cnos.py
+++ b/plugins/module_utils/network/cnos/cnos.py
@@ -73,7 +73,7 @@ cnos_provider_spec = {
 }
 
 cnos_argument_spec = {
-    'provider': dict(type='dict', options=cnos_provider_spec, removed_at_date="2022-09-25"),
+    'provider': dict(type='dict', options=cnos_provider_spec, removed_in_version='4.0.0'),
 }
 
 command_spec = {

--- a/plugins/module_utils/network/enos/enos.py
+++ b/plugins/module_utils/network/enos/enos.py
@@ -57,7 +57,7 @@ enos_provider_spec = {
 }
 
 enos_argument_spec = {
-    'provider': dict(type='dict', options=enos_provider_spec, removed_at_date="2022-09-25"),
+    'provider': dict(type='dict', options=enos_provider_spec, removed_in_version='4.0.0'),
 }
 
 command_spec = {

--- a/plugins/module_utils/network/enos/enos.py
+++ b/plugins/module_utils/network/enos/enos.py
@@ -57,7 +57,8 @@ enos_provider_spec = {
 }
 
 enos_argument_spec = {
-    'provider': dict(type='dict', options=enos_provider_spec, removed_in_version='4.0.0'),
+    'provider': dict(type='dict', options=enos_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network'),
 }
 
 command_spec = {

--- a/plugins/module_utils/network/enos/enos.py
+++ b/plugins/module_utils/network/enos/enos.py
@@ -57,7 +57,7 @@ enos_provider_spec = {
 }
 
 enos_argument_spec = {
-    'provider': dict(type='dict', options=enos_provider_spec),
+    'provider': dict(type='dict', options=enos_provider_spec, removed_at_date="2022-09-25"),
 }
 
 command_spec = {

--- a/plugins/module_utils/network/ironware/ironware.py
+++ b/plugins/module_utils/network/ironware/ironware.py
@@ -39,7 +39,8 @@ ironware_provider_spec = {
 }
 
 ironware_argument_spec = {
-    'provider': dict(type='dict', options=ironware_provider_spec, removed_in_version='4.0.0')
+    'provider': dict(type='dict', options=ironware_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network')
 }
 
 command_spec = {

--- a/plugins/module_utils/network/ironware/ironware.py
+++ b/plugins/module_utils/network/ironware/ironware.py
@@ -39,7 +39,7 @@ ironware_provider_spec = {
 }
 
 ironware_argument_spec = {
-    'provider': dict(type='dict', options=ironware_provider_spec, removed_at_date="2022-09-25")
+    'provider': dict(type='dict', options=ironware_provider_spec, removed_in_version='4.0.0')
 }
 
 command_spec = {

--- a/plugins/module_utils/network/ironware/ironware.py
+++ b/plugins/module_utils/network/ironware/ironware.py
@@ -39,7 +39,7 @@ ironware_provider_spec = {
 }
 
 ironware_argument_spec = {
-    'provider': dict(type='dict', options=ironware_provider_spec)
+    'provider': dict(type='dict', options=ironware_provider_spec, removed_at_date="2022-09-25")
 }
 
 command_spec = {

--- a/plugins/module_utils/network/sros/sros.py
+++ b/plugins/module_utils/network/sros/sros.py
@@ -50,7 +50,8 @@ sros_provider_spec = {
     'timeout': dict(type='int'),
 }
 sros_argument_spec = {
-    'provider': dict(type='dict', options=sros_provider_spec),
+    'provider': dict(type='dict', options=sros_provider_spec, removed_in_version='4.0.0',
+                     removed_from_collection='community.network'),
 }
 sros_top_spec = {
     'host': dict(removed_in_version='0.2.0',


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes:
https://github.com/ansible-collections/community.network/issues/119

*  For platforms using persistent allow network_cli connection type
   In ansible 2.6 `network_cli` connection was added as first class
   connection, however some of the community platform code was not
   updated to use `network_cli`.
*  Deprecate local connection type for platforms that use persistent
   connection framework and have cliconf and terminal plugins
   implemented.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/ce.py
plugins/action/cnos.py
plugins/action/enos.py
plugins/action/ironware.py
plugins/action/sros.py
plugins/module_utils/network/aireos/aireos.py
plugins/module_utils/network/aruba/aruba.py
plugins/module_utils/network/cloudengine/ce.py
plugins/module_utils/network/cnos/cnos.py
plugins/module_utils/network/enos/enos.py
plugins/module_utils/network/ironware/ironware.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
