### PR TITLE
Change vendored ipaddress import to regular import

### DIFF
--- a/changelogs/fragments/netcommon_ipaddress.yaml
+++ b/changelogs/fragments/netcommon_ipaddress.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - cnos_static_route - Move ipaddress import from ansible.netcommon to builtin
+    or package before ipaddress is removed from ansible.netcommon

--- a/changelogs/fragments/netcommon_ipaddress.yaml
+++ b/changelogs/fragments/netcommon_ipaddress.yaml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+breaking_changes:
   - cnos_static_route - move ipaddress import from ansible.netcommon to builtin
     or package before ipaddress is removed from ansible.netcommon. You need to
     make sure to have the ipaddress package installed if you are using this

--- a/changelogs/fragments/netcommon_ipaddress.yaml
+++ b/changelogs/fragments/netcommon_ipaddress.yaml
@@ -1,4 +1,7 @@
 ---
 minor_changes:
-  - cnos_static_route - Move ipaddress import from ansible.netcommon to builtin
-    or package before ipaddress is removed from ansible.netcommon
+  - cnos_static_route - move ipaddress import from ansible.netcommon to builtin
+    or package before ipaddress is removed from ansible.netcommon. You need to
+    make sure to have the ipaddress package installed if you are using this
+    module on Python 2.7
+    (https://github.com/ansible-collections/community.network/pull/129).

--- a/plugins/modules/network/cnos/cnos_static_route.py
+++ b/plugins/modules/network/cnos/cnos_static_route.py
@@ -112,13 +112,18 @@ commands:
 """
 from copy import deepcopy
 from re import findall
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import validate_ip_address
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import remove_default_spec
 from ansible_collections.community.network.plugins.module_utils.network.cnos.cnos import get_config, load_config
 from ansible_collections.community.network.plugins.module_utils.network.cnos.cnos import check_args
 from ansible_collections.community.network.plugins.module_utils.network.cnos.cnos import cnos_argument_spec
+
+try:
+    import ipaddress
+    HAS_IPADDRESS = True
+except ImportError:
+    HAS_IPADDRESS = False
 
 
 def map_obj_to_commands(want, have):
@@ -259,6 +264,8 @@ def main():
                            required_one_of=required_one_of,
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
+    if not HAS_IPADDRESS:
+        module.fail_json(msg=missing_required_lib("ipaddress"))
 
     warnings = list()
     check_args(module, warnings)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

`ipaddress` will be removed from `ansible.netcommon` after ansible-collections/ansible.netcommon#93 is merged.

This is the only instance I could find using the version from netcommon.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request?

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cnos_static_route