### PR TITLE
Update routeros.py

### DIFF
--- a/changelogs/fragments/138-routeros-allow-slash.yml
+++ b/changelogs/fragments/138-routeros-allow-slash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "routeros terminal plugin - allow slashes in hostnames for terminal detection. Without this, slashes in hostnames will result in connection timeouts (https://github.com/ansible-collections/community.network/pull/138)."

--- a/plugins/terminal/routeros.py
+++ b/plugins/terminal/routeros.py
@@ -47,7 +47,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"\x1b<"),
-        re.compile(br"\[[\w\.]+\@[\w\s\-\.]+\] ?> ?$"),
+        re.compile(br"\[[\w\.]+\@[\w\s\-\.\/]+\] ?> ?$"),
         re.compile(br"Please press \"Enter\" to continue!"),
         re.compile(br"Do you want to see the software license\? \[Y\/n\]: ?"),
     ]


### PR DESCRIPTION
Adjust the terminal detection line to support forward slashes in device hostnames (connections fail without clear reason otherwise)

##### SUMMARY
My RouterOS units have forward slashes in their system identities.  The way the regex is structured prevents terminal detection from succeeding in this case, and devices will fail silently.  The regex is still probably overly strict, but it fixed my problem.

##### ISSUE TYPE
- Bugfix Pull Request