### PR TITLE
Fix and deprecate fortimanager httpapi plugin

### DIFF
--- a/changelogs/fragments/fortimanager-imports.yml
+++ b/changelogs/fragments/fortimanager-imports.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- "fortimanager httpapi plugin - fix imports to load module_utils from fortios.fortimanager, where it actually exists. Please note that you must have the fortios.fortimanager collection installed for the plugin to work (https://github.com/ansible-collections/community.network/pull/151)."
+major_changes:
+- "In community.network 2.0.0, the ``fortimanager`` httpapi plugin will be removed and replaced by a redirect to the corresponding plugin in the fortios.fortimanager collection. For Ansible 2.10 and ansible-base 2.10 users, this means that it will continue to work assuming that collection is installed. For Ansible 2.9 users, this means that they have to adjust the FQCN from ``community.network.fortimanager`` to ``fortios.fortimanager.fortimanager`` (https://github.com/ansible-collections/community.network/pull/151)."

--- a/plugins/httpapi/fortimanager.py
+++ b/plugins/httpapi/fortimanager.py
@@ -33,12 +33,18 @@ description:
 '''
 
 import json
+from ansible.errors import AnsibleError
 from ansible.plugins.httpapi import HttpApiBase
 from ansible.module_utils.basic import to_text
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import BASE_HEADERS
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
+
+try:
+    from ansible_collections.fortinet.fortimanager.plugins.module_utils.common import BASE_HEADERS
+    from ansible_collections.fortinet.fortimanager.plugins.module_utils.common import FMGBaseException
+    from ansible_collections.fortinet.fortimanager.plugins.module_utils.common import FMGRCommon
+    from ansible_collections.fortinet.fortimanager.plugins.module_utils.common import FMGRMethods
+    HAS_FORTIMANAGER_COLLECTION = True
+except ImportError:
+    HAS_FORTIMANAGER_COLLECTION = False
 
 
 class HttpApi(HttpApiBase):
@@ -62,6 +68,8 @@ class HttpApi(HttpApiBase):
         self._uses_adoms = False
         self._adom_list = list()
         self._logged_in_user = None
+        if not HAS_FORTIMANAGER_COLLECTION:
+            raise AnsibleError("The community.network.fortimanager httpapi plugin requires the fortios.fortimanager collection.")
 
     def set_become(self, become_context):
         """


### PR DESCRIPTION
##### SUMMARY
The deprecation is only announced in the changelog since we replace the plugin by a redirect instead of just removing it.

Fixes #148.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/httpapi/fortimanager.py
