### PR TITLE
add support for more edgeos prompts

### DIFF
--- a/plugins/terminal/edgeos.py
+++ b/plugins/terminal/edgeos.py
@@ -15,6 +15,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"[\r\n]?(\([^\)]+\)) (?:>|#) ?$"),
         re.compile(br"\@[\w\-\.]+:\S+?[>#\$] ?$")
     ]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The prompts for edgeos devices can be in the format
`(hostname) >`
`(hostname) #`
this PR adds support for those prompts in the terminal edgeos plugin.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #98

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
edgeos_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
