### PR TITLE
edgeos_config - added diff result

### DIFF
--- a/changelogs/fragments/add-edgeos-config-diff.yml
+++ b/changelogs/fragments/add-edgeos-config-diff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "edgeos_config - added diff result when applying configuration changes (https://github.com/ansible-collections/community.network/pull/184)."

--- a/plugins/module_utils/network/edgeos/edgeos.py
+++ b/plugins/module_utils/network/edgeos/edgeos.py
@@ -117,8 +117,7 @@ def load_config(module, commands, commit=False, comment=None):
         out = to_text(out, errors='surrogate_or_strict')
 
         if not out.startswith('No changes'):
-            out = connection.get('show')
-            diff = to_text(out, errors='surrogate_or_strict').strip()
+            diff = out.strip()
 
     if commit:
         try:

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -255,8 +255,10 @@ def run(module, result):
     comment = module.params['comment']
 
     if commands:
-        load_config(module, commands, commit=commit, comment=comment)
+        prepared_diff = {}
+        prepared_diff['prepared'] = load_config(module, commands, commit=commit, comment=comment)
 
+        result['diff'] = prepared_diff
         result['changed'] = True
 
 


### PR DESCRIPTION
##### SUMMARY
Add diff output when applying changes using edgeos_config

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION

This will print the full router config with changes shown in the edgeos json format (using the 'show' command)
```
         rule 5002 {
             description "masquerade for WAN 2"
             outbound-interface eth6
             type masquerade
         }
         rule 5003 {
>            description "masquerade for WAN 3"
             outbound-interface eth7
             type masquerade
         }
```