### PR TITLE
add command and config modules for edgeswitch

### DIFF
--- a/plugins/modules/edgeswitch_command.py
+++ b/plugins/modules/edgeswitch_command.py
@@ -1,0 +1,1 @@
+./network/edgeswitch/edgeswitch_command.py

--- a/plugins/modules/edgeswitch_config.py
+++ b/plugins/modules/edgeswitch_config.py
@@ -1,0 +1,1 @@
+./network/edgeswitch/edgeswitch_config.py

--- a/plugins/modules/network/edgeswitch/edgeswitch_command.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_command.py
@@ -32,12 +32,14 @@ options:
         If the C(wait_for) argument is provided, the module is not returned
         until the condition is met or the number of retries is exceeded.
     required: True
+    type: list
   wait_for:
     description:
       - Causes the task to wait for a specific condition to be met before
         moving forward. If the condition is not met before the specified
         number of retries is exceeded, the task will fail.
     required: False
+    type: list
   match:
     description:
       - Used in conjunction with C(wait_for) to create match policy. If set to
@@ -46,6 +48,7 @@ options:
     required: False
     default: 'all'
     choices: ['any', 'all']
+    type: str
   retries:
     description:
       - Number of times a command should be tried before it is considered failed.
@@ -53,11 +56,13 @@ options:
         C(wait_for) conditionals.
     required: False
     default: 10
+    type: int
   interval:
     description:
       - The number of seconds to wait between C(retries) of the command.
     required: False
     default: 1
+    type: int
 
 notes:
   - Tested against EdgeSwitch 1.9.2

--- a/plugins/modules/network/edgeswitch/edgeswitch_command.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_command.py
@@ -120,8 +120,8 @@ def parse_commands(module, warnings):
 
 def main():
     spec = dict(
-        commands=dict(type='list', required=True),
-        wait_for=dict(type='list'),
+        commands=dict(type='list', elements='str', required=True),
+        wait_for=dict(type='list', elements='str'),
         match=dict(default='all', choices=['all', 'any']),
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int')

--- a/plugins/modules/network/edgeswitch/edgeswitch_command.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_command.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+module: edgeswitch_command
+author:
+  - Matt Haught (@haught)
+  - Chad Norgan (@beardymcbeards)
+  - Sam Doran (@samdoran)
+short_description: Run one or more commands on EdgeSwitch devices
+description:
+  - This command module allows running one or more commands on a remote
+    device running EdgeSwitch, such as the Ubiquiti EdgePoint S16.
+  - This module does not support running commands in configuration mode.
+  - Certain C(show) commands in EdgeSwitch produce many lines of output and
+    use a custom pager that can cause this module to hang.  If the
+    value of the environment variable C(ANSIBLE_EDGESWITCH_TERMINAL_LENGTH)
+    is not set, the default number of 10000 is used.
+  - "This is a network module and requires C(connection: network_cli)
+    in order to work properly."
+  - For more information please see the L(Network Guide,../network/getting_started/index.html).
+options:
+  commands:
+    description:
+      - The commands or ordered set of commands that should be run against the
+        remote device. The output of the command is returned to the playbook.
+        If the C(wait_for) argument is provided, the module is not returned
+        until the condition is met or the number of retries is exceeded.
+    required: True
+  wait_for:
+    description:
+      - Causes the task to wait for a specific condition to be met before
+        moving forward. If the condition is not met before the specified
+        number of retries is exceeded, the task will fail.
+    required: False
+  match:
+    description:
+      - Used in conjunction with C(wait_for) to create match policy. If set to
+        C(all), then all conditions in C(wait_for) must be met. If set to
+        C(any), then only one condition must match.
+    required: False
+    default: 'all'
+    choices: ['any', 'all']
+  retries:
+    description:
+      - Number of times a command should be tried before it is considered failed.
+        The command is run on the target device and evaluated against the
+        C(wait_for) conditionals.
+    required: False
+    default: 10
+  interval:
+    description:
+      - The number of seconds to wait between C(retries) of the command.
+    required: False
+    default: 1
+
+notes:
+  - Tested against EdgeSwitch 1.9.2
+'''
+
+EXAMPLES = """
+tasks:
+  - name: Reboot the device
+    community.network.edgeswitch_command:
+      commands: reload now
+
+  - name: Show the configuration for eth0 and eth1
+    community.network.edgeswitch_command:
+      commands: show interfaces switchport {{ item }}
+    loop:
+      - 0/1
+      - 0/2
+"""
+
+RETURN = """
+stdout:
+  description: The set of responses from the commands
+  returned: always apart from low level errors (such as action plugin)
+  type: list
+  sample: ['...', '...']
+stdout_lines:
+  description: The value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+"""
+import time
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import Conditional
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import transform_commands, to_lines
+from ansible_collections.community.network.plugins.module_utils.network.edgeswitch.edgeswitch import run_commands
+
+
+def parse_commands(module, warnings):
+    commands = transform_commands(module)
+
+    if module.check_mode:
+        for item in list(commands):
+            if not item['command'].startswith('show'):
+                warnings.append(
+                    'Only show commands are supported when using check mode, not '
+                    'executing %s' % item['command']
+                )
+                commands.remove(item)
+
+    return commands
+
+
+def main():
+    spec = dict(
+        commands=dict(type='list', required=True),
+        wait_for=dict(type='list'),
+        match=dict(default='all', choices=['all', 'any']),
+        retries=dict(default=10, type='int'),
+        interval=dict(default=1, type='int')
+    )
+
+    module = AnsibleModule(argument_spec=spec, supports_check_mode=True)
+
+    warnings = list()
+    result = {'changed': False, 'warnings': warnings}
+    commands = parse_commands(module, warnings)
+    wait_for = module.params['wait_for'] or list()
+
+    try:
+        conditionals = [Conditional(c) for c in wait_for]
+    except AttributeError as exc:
+        module.fail_json(msg=to_text(exc))
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not been satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result.update({
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses)),
+    })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/network/edgeswitch/edgeswitch_command.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_command.py
@@ -33,6 +33,7 @@ options:
         until the condition is met or the number of retries is exceeded.
     required: True
     type: list
+    elements: str
   wait_for:
     description:
       - Causes the task to wait for a specific condition to be met before
@@ -40,6 +41,7 @@ options:
         number of retries is exceeded, the task will fail.
     required: False
     type: list
+    elements: str
   match:
     description:
       - Used in conjunction with C(wait_for) to create match policy. If set to

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -393,13 +393,16 @@ def main():
     if module.params['save_when'] == 'always':
         save_config(module, result)
     elif module.params['save_when'] == 'modified':
-        output = run_commands(module, ['show running-config', 'show configuration'])
+        output = run_commands(module, ['show running-config', 'show startup-config'])
 
         running_config = NetworkConfig(contents=output[0], ignore_lines=diff_ignore_lines)
         startup_config = NetworkConfig(contents=output[1], ignore_lines=diff_ignore_lines)
 
-        if running_config.sha1 != startup_config.sha1:
-            save_config(module, result)
+        # NetworkConfig.sha1 does not ignore lines, so do a difference which does
+        diff = running_config.difference(startup_config)
+        if diff:
+          save_config(module, result)
+
     elif module.params['save_when'] == 'changed':
         if result['changed']:
             save_config(module, result)

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -30,6 +30,7 @@ options:
         device config parser.
     aliases: ['commands']
     type: list
+    elements: str
   parents:
     description:
       - The ordered set of parents that uniquely identify the section or hierarchy
@@ -37,6 +38,7 @@ options:
         is omitted, the commands are checked against the set of top
         level or global commands.
     type: list
+    elements: str
   src:
     description:
       - Specifies the source path to the file that contains the configuration
@@ -53,6 +55,7 @@ options:
         any changes without affecting how the set of commands are matched
         against the system.
     type: list
+    elements: str
   after:
     description:
       - The ordered set of commands to append to the end of the command
@@ -60,6 +63,7 @@ options:
         allows the playbook designer to append a set of commands to be
         executed after the command set.
     type: list
+    elements: str
   match:
     description:
       - Instructs the module on the way to perform the matching of
@@ -141,6 +145,7 @@ options:
         that are automatically updated by the system.  This argument takes
         a list of regular expressions or exact line matches.
     type: list
+    elements: str
   intended_config:
     description:
       - The C(intended_config) provides the master configuration that

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: edgeswitch_config
-author: 
+author:
   - "Matt Haught (@haught)"
   - "James Mighion (@jmighion)"
 short_description: Manage Edgeswitch configuration sections
@@ -29,12 +29,14 @@ options:
         command syntax as some commands are automatically modified by the
         device config parser.
     aliases: ['commands']
+    type: list
   parents:
     description:
       - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.
+    type: list
   src:
     description:
       - Specifies the source path to the file that contains the configuration
@@ -42,6 +44,7 @@ options:
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
         exclusive with I(lines), I(parents).
+    type: path
   before:
     description:
       - The ordered set of commands to push on to the command stack if
@@ -49,12 +52,14 @@ options:
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
+    type: list
   after:
     description:
       - The ordered set of commands to append to the end of the command
         stack if a change needs to be made.  Just like with I(before) this
         allows the playbook designer to append a set of commands to be
         executed after the command set.
+    type: list
   match:
     description:
       - Instructs the module on the way to perform the matching of
@@ -67,6 +72,7 @@ options:
         the running configuration on the remote device.
     default: line
     choices: ['line', 'strict', 'exact', 'none']
+    type: str
   replace:
     description:
       - Instructs the module on the way to perform the configuration
@@ -77,6 +83,7 @@ options:
         line is not correct.
     default: line
     choices: ['line', 'block']
+    type: str
   backup:
     description:
       - This argument will cause the module to create a full backup of
@@ -96,6 +103,7 @@ options:
         implementer to pass in the configuration to use as the base
         config for comparison.
     aliases: ['config']
+    type: str
   save_when:
     description:
       - When changes are made to the device running-configuration, the
@@ -111,6 +119,7 @@ options:
         will only be copied to the startup configuration if the task has made a change.
     default: never
     choices: ['always', 'never', 'modified', 'changed']
+    type: str
   diff_against:
     description:
       - When using the C(ansible-playbook --diff) command line argument
@@ -124,12 +133,14 @@ options:
         return the before and after diff of the running-config with respect
         to any changes made to the device configuration.
     choices: ['startup', 'intended', 'running']
+    type: str
   diff_ignore_lines:
     description:
       - Use this argument to specify one or more lines that should be
         ignored during the diff.  This is used for lines in the configuration
         that are automatically updated by the system.  This argument takes
         a list of regular expressions or exact line matches.
+    type: list
   intended_config:
     description:
       - The C(intended_config) provides the master configuration that
@@ -139,6 +150,7 @@ options:
         of the current device's configuration against.  When specifying this
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
+    type: str
   backup_options:
     description:
       - This is a dict object containing configurable options related to backup file path.
@@ -150,6 +162,7 @@ options:
           - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
+        type: str
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
@@ -273,7 +286,7 @@ def get_candidate(module):
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
-        run_commands(module, { 'command':'write memory', 'prompt':'Are you sure you want to save', 'answer':'y' } )
+        run_commands(module, {'command':'write memory', 'prompt':'Are you sure you want to save', 'answer':'y'})
     else:
         module.warn('Skipping command `write memory` '
                     'due to check_mode.  Configuration not copied to '

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -401,7 +401,7 @@ def main():
         # NetworkConfig.sha1 does not ignore lines, so do a difference which does
         diff = running_config.difference(startup_config)
         if diff:
-          save_config(module, result)
+            save_config(module, result)
 
     elif module.params['save_when'] == 'changed':
         if result['changed']:

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -10,8 +10,9 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: edgeswitch_config
-author: "Matt Haught (@haught)"
-        "James Mighion (@jmighion)"
+author: 
+  - "Matt Haught (@haught)"
+  - "James Mighion (@jmighion)"
 short_description: Manage Edgeswitch configuration sections
 description:
   - Edgeswitch configurations use a flat nonindented file syntax

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -247,6 +247,7 @@ def get_running_config(module, config=None):
             contents = get_config(module)
     return NetworkConfig(contents=indent_config(contents))
 
+
 def indent_config(config):
     """ indent the config so we can modify sections natively
     """
@@ -286,7 +287,7 @@ def get_candidate(module):
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
-        run_commands(module, {'command':'write memory', 'prompt':'Are you sure you want to save', 'answer':'y'})
+        run_commands(module, {'command': 'write memory', 'prompt': 'Are you sure you want to save', 'answer': 'y'})
     else:
         module.warn('Skipping command `write memory` '
                     'due to check_mode.  Configuration not copied to '
@@ -303,11 +304,11 @@ def main():
     argument_spec = dict(
         src=dict(type='path'),
 
-        lines=dict(aliases=['commands'], type='list'),
-        parents=dict(type='list'),
+        lines=dict(aliases=['commands'], type='list', elements='str'),
+        parents=dict(type='list', elements='str'),
 
-        before=dict(type='list'),
-        after=dict(type='list'),
+        before=dict(type='list', elements='str'),
+        after=dict(type='list', elements='str'),
 
         match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
         replace=dict(default='line', choices=['line', 'block']),
@@ -321,7 +322,7 @@ def main():
         save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 
         diff_against=dict(choices=['running', 'startup', 'intended']),
-        diff_ignore_lines=dict(type='list'),
+        diff_ignore_lines=dict(type='list', elements='str'),
     )
 
     mutually_exclusive = [('lines', 'src'),

--- a/plugins/modules/network/edgeswitch/edgeswitch_config.py
+++ b/plugins/modules/network/edgeswitch/edgeswitch_config.py
@@ -1,0 +1,427 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Team
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: edgeswitch_config
+author: "Matt Haught (@haught)"
+        "James Mighion (@jmighion)"
+short_description: Manage Edgeswitch configuration sections
+description:
+  - Edgeswitch configurations use a flat nonindented file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with Edgeswitch configuration sections
+    in a deterministic way.
+
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section or hierarchy
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is mutually
+        exclusive with I(lines), I(parents).
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory. If the directory does not exist, it is created.
+    type: bool
+    default: 'no'
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    aliases: ['config']
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that before.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup configuration and the I(modified) flag will always be set to
+        True.  If the argument is set to I(modified), then the running-config
+        will only be copied to the startup configuration if it has changed since
+        the last save to startup configuration.  If the argument is set to
+        I(never), the running-config will never be copied to the
+        startup configuration.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup configuration if the task has made a change.
+    default: never
+    choices: ['always', 'never', 'modified', 'changed']
+  diff_against:
+    description:
+      - When using the C(ansible-playbook --diff) command line argument
+        the module can generate diffs against different sources.
+      - When this option is configure as I(startup), the module will return
+        the diff of the running-config against the startup configuration.
+      - When this option is configured as I(intended), the module will
+        return the diff of the running-config against the configuration
+        provided in the C(intended_config) argument.
+      - When this option is configured as I(running), the module will
+        return the before and after diff of the running-config with respect
+        to any changes made to the device configuration.
+    choices: ['startup', 'intended', 'running']
+  diff_ignore_lines:
+    description:
+      - Use this argument to specify one or more lines that should be
+        ignored during the diff.  This is used for lines in the configuration
+        that are automatically updated by the system.  This argument takes
+        a list of regular expressions or exact line matches.
+  intended_config:
+    description:
+      - The C(intended_config) provides the master configuration that
+        the node should conform to and is used to check the final
+        running-config against.   This argument will not modify any settings
+        on the remote device and is strictly used to check the compliance
+        of the current device's configuration against.  When specifying this
+        argument, the task should also modify the C(diff_against) value and
+        set it to I(intended).
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exist it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+    type: dict
+
+notes:
+  - Tested against EdgeSwitch 1.9.2
+'''
+
+EXAMPLES = """
+- name: Configure top level configuration
+  community.network.edgeswitch_config:
+    lines: domain-name example.net
+
+- name: Diff the running-config against a provided config
+  community.network.edgeswitch_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', 'master.cfg') }}"
+
+- name: Configure interface settings
+  community.network.edgeswitch_config:
+    lines:
+      - description test interface
+      - ip access-group EXAMPLE in
+    parents: interface 0/1
+
+- name: Load new acl into device
+  community.network.edgeswitch_config:
+    lines:
+      - deny tcp 10.0.1.0 0.0.255.255 host 10.10.10.10 eq 443
+      - permit ip any any
+    parents: ip access-list EXAMPLE
+    before: no ip access-list EXAMPLE
+    match: exact
+
+- name: Configurable backup path
+  community.network.edgeswitch_config:
+    backup: yes
+    lines: domain-name example.net
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
+"""
+
+RETURN = """
+commands:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['domain-name example.net', 'vlan database', 'vlan name 932 "VLAN 932"']
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['domain-name example.net', 'vlan database', 'vlan name 932 "VLAN 932"']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: str
+  sample: /playbooks/ansible/backup/edgeswitch_config.2016-07-16@22:28:34
+"""
+
+import re
+
+from ansible_collections.community.network.plugins.module_utils.network.edgeswitch.edgeswitch import run_commands, get_config, load_config
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig, dumps
+
+
+def get_running_config(module, config=None):
+    contents = module.params['running_config']
+    if not contents:
+        if config:
+            contents = config
+        else:
+            contents = get_config(module)
+    return NetworkConfig(contents=indent_config(contents))
+
+def indent_config(config):
+    """ indent the config so we can modify sections natively
+    """
+    parent_re = [
+        re.compile(r"^(?:vlan\sdatabase)$"),
+        re.compile(r"^(?:ip\saccess-list\s\S+)$"),
+        re.compile(r"^(?:line\s\S+)$"),
+        re.compile(r"^(?:interface\s\S+)$"),
+        re.compile(r"^(?:interface\slag\s\S+)$"),
+        re.compile(r"^(?:service\s\S+)$"),
+    ]
+    config_indented = list()
+    indent = False
+    for line in str(config).split("\n"):
+        if any(regex.match(line) for regex in parent_re):
+            config_indented.append(line)
+            indent = True
+        elif line == 'exit':
+            config_indented.append(line)
+            indent = False
+        else:
+            config_indented.append(" %s" % line if indent else line)
+    return "\n".join(config_indented)
+
+
+def get_candidate(module):
+    candidate = NetworkConfig()
+
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def save_config(module, result):
+    result['changed'] = True
+    if not module.check_mode:
+        run_commands(module, { 'command':'write memory', 'prompt':'Are you sure you want to save', 'answer':'y' } )
+    else:
+        module.warn('Skipping command `write memory` '
+                    'due to check_mode.  Configuration not copied to '
+                    'non-volatile storage')
+
+
+def main():
+    """ main entry point for module execution
+    """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+
+        running_config=dict(aliases=['config']),
+        intended_config=dict(),
+
+        backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
+
+        save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
+
+        diff_against=dict(choices=['running', 'startup', 'intended']),
+        diff_ignore_lines=dict(type='list'),
+    )
+
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('diff_against', 'intended', ['intended_config'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    warnings = list()
+
+    result = {'changed': False, 'warnings': warnings}
+
+    config = None
+
+    if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
+        contents = get_config(module)
+        config = NetworkConfig(contents=contents)
+        if module.params['backup']:
+            result['__backup__'] = contents
+
+    if any((module.params['src'], module.params['lines'])):
+        match = module.params['match']
+        replace = module.params['replace']
+
+        candidate = get_candidate(module)
+
+        if match != 'none':
+            config = get_running_config(module, config)
+            path = module.params['parents']
+            configobjs = candidate.difference(config, match=match, replace=replace, path=path)
+        else:
+            configobjs = candidate.items
+
+        if configobjs:
+            commands = dumps(configobjs, 'commands').split('\n')
+
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+            result['updates'] = commands
+
+            if not module.check_mode:
+                load_config(module, commands)
+
+            result['changed'] = True
+
+    running_config = None
+    startup_config = None
+
+    diff_ignore_lines = module.params['diff_ignore_lines']
+
+    if module.params['save_when'] == 'always':
+        save_config(module, result)
+    elif module.params['save_when'] == 'modified':
+        output = run_commands(module, ['show running-config', 'show configuration'])
+
+        running_config = NetworkConfig(contents=output[0], ignore_lines=diff_ignore_lines)
+        startup_config = NetworkConfig(contents=output[1], ignore_lines=diff_ignore_lines)
+
+        if running_config.sha1 != startup_config.sha1:
+            save_config(module, result)
+    elif module.params['save_when'] == 'changed':
+        if result['changed']:
+            save_config(module, result)
+
+    if module._diff:
+        if not running_config:
+            output = run_commands(module, 'show running-config')
+            contents = output[0]
+        else:
+            contents = running_config.config_text
+
+        # recreate the object in order to process diff_ignore_lines
+        running_config = NetworkConfig(contents=contents, ignore_lines=diff_ignore_lines)
+
+        if module.params['diff_against'] == 'running':
+            if module.check_mode:
+                module.warn("unable to perform diff against running-config due to check mode")
+                contents = None
+            else:
+                contents = config.config_text
+
+        elif module.params['diff_against'] == 'startup':
+            if not startup_config:
+                output = run_commands(module, 'show startup-config')
+                contents = output[0]
+            else:
+                contents = startup_config.config_text
+
+        elif module.params['diff_against'] == 'intended':
+            contents = module.params['intended_config']
+
+        if contents is not None:
+            base_config = NetworkConfig(contents=contents, ignore_lines=diff_ignore_lines)
+
+            if running_config.sha1 != base_config.sha1:
+                result.update({
+                    'changed': True,
+                    'diff': {'before': str(base_config), 'after': str(running_config)}
+                })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/plugins/modules/network/edgeswitch/fixtures/edgeswitch_command_show_version
+++ b/tests/unit/plugins/modules/network/edgeswitch/fixtures/edgeswitch_command_show_version
@@ -1,0 +1,8 @@
+System Description............................. EdgePoint S16, 1.9.2, Linux 3.6.5-03329b4a, 1.1.0.5102011
+Machine Type................................... EdgePoint S16
+Machine Model.................................. EP-S16
+Serial Number.................................. 74ACB9A3E1A9
+Part Number.................................... 13-02203
+Burned In MAC Address.......................... 74:AC:B9:A3:E1:A9
+Software Version............................... 1.9.2
+Hardware Revision.............................. 20

--- a/tests/unit/plugins/modules/network/edgeswitch/fixtures/edgeswitch_config_config.cfg
+++ b/tests/unit/plugins/modules/network/edgeswitch/fixtures/edgeswitch_config_config.cfg
@@ -1,0 +1,16 @@
+domain-name bar
+!
+interface 0/1
+ ip address 1.2.3.4 255.255.255.0
+ description test-string
+exit
+!
+interface 0/2
+ ip address 6.7.8.9 255.255.255.0
+ description test-string
+ shutdown
+exit
+!
+ip access-list EXAMPLE in
+ any any any permit
+exit

--- a/tests/unit/plugins/modules/network/edgeswitch/fixtures/edgeswitch_config_src.cfg
+++ b/tests/unit/plugins/modules/network/edgeswitch/fixtures/edgeswitch_config_src.cfg
@@ -1,0 +1,15 @@
+domain-name foo
+!
+interface 0/1
+ no ip address
+exit
+!
+interface 0/2
+ ip address 6.7.8.9 255.255.255.0
+ description test-string
+ shutdown
+exit
+!
+ip access-list EXAMPLE in
+ any any any permit
+exit

--- a/tests/unit/plugins/modules/network/edgeswitch/test_edgeswitch_command.py
+++ b/tests/unit/plugins/modules/network/edgeswitch/test_edgeswitch_command.py
@@ -1,0 +1,106 @@
+# (c) 2018 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import json
+
+from ansible_collections.community.network.tests.unit.compat.mock import patch
+from ansible_collections.community.network.plugins.modules.network.edgeswitch import edgeswitch_command
+from ansible_collections.community.network.tests.unit.plugins.modules.utils import set_module_args
+from .edgeswitch_module import TestEdgeswitchModule, load_fixture
+
+
+class TestEdgeswitchCommandModule(TestEdgeswitchModule):
+
+    module = edgeswitch_command
+
+    def setUp(self):
+        super(TestEdgeswitchCommandModule, self).setUp()
+        self.mock_run_commands = patch('ansible_collections.community.network.plugins.modules.network.edgeswitch.edgeswitch_command.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestEdgeswitchCommandModule, self).tearDown()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        def load_from_file(*args, **kwargs):
+            module, commands = args
+            output = list()
+
+            for item in commands:
+                try:
+                    obj = json.loads(item)
+                    command = obj['command']
+                except (ValueError, TypeError):
+                    command = item['command']
+                filename = 'edgeswitch_command_' + str(command).replace(' ', '_')
+                output.append(load_fixture(filename))
+            return output
+
+        self.run_commands.side_effect = load_from_file
+
+    def test_edgeswitch_command_simple(self):
+        set_module_args(dict(commands=['show version']))
+        result = self.execute_module()
+        self.assertEqual(len(result['stdout']), 1)
+        self.assertTrue(result['stdout'][0].startswith('System Description'))
+
+    def test_edgeswitch_command_multiple(self):
+        set_module_args(dict(commands=['show version', 'show version']))
+        result = self.execute_module()
+        self.assertEqual(len(result['stdout']), 2)
+        self.assertTrue(result['stdout'][0].startswith('System Description'))
+
+    def test_edgeswitch_commond_wait_for(self):
+        wait_for = 'result[0] contains "EP-S16"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for))
+        self.execute_module()
+
+    def test_edgeswitch_command_wait_for_fails(self):
+        wait_for = 'result[0] contains "bad string"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for))
+        self.execute_module(failed=True)
+        self.assertEqual(self.run_commands.call_count, 10)
+
+    def test_edgeswitch_command_retries(self):
+        wait_for = 'result[0] contains "bad string"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, retries=2))
+        self.execute_module(failed=True)
+        self.assertEqual(self.run_commands.call_count, 2)
+
+    def test_edgeswitch_command_match_any(self):
+        wait_for = ['result[0] contains "EP-S16"',
+                    'result[0] contains "bad string"']
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, match='any'))
+        self.execute_module()
+
+    def test_edgeswitch_command_match_all(self):
+        wait_for = ['result[0] contains "EP-S16"',
+                    'result[0] contains "EdgePoint"']
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, match='all'))
+        self.execute_module()
+
+    def test_vyos_command_match_all_failure(self):
+        wait_for = ['result[0] contains "EP-S16"',
+                    'result[0] contains "bad string"']
+        commands = ['show version', 'show version']
+        set_module_args(dict(commands=commands, wait_for=wait_for, match='all'))
+        self.execute_module(failed=True)

--- a/tests/unit/plugins/modules/network/edgeswitch/test_edgeswitch_config.py
+++ b/tests/unit/plugins/modules/network/edgeswitch/test_edgeswitch_config.py
@@ -168,4 +168,3 @@ class TestEdgeswitchConfigModule(TestEdgeswitchModule):
         set_module_args(dict(lines=lines, parents=parents, match='exact'))
         commands = parents + lines
         self.execute_module(changed=True, commands=commands, sort=False)
-

--- a/tests/unit/plugins/modules/network/edgeswitch/test_edgeswitch_config.py
+++ b/tests/unit/plugins/modules/network/edgeswitch/test_edgeswitch_config.py
@@ -1,0 +1,171 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.network.tests.unit.compat.mock import patch
+from ansible_collections.community.network.plugins.modules.network.edgeswitch import edgeswitch_config
+from ansible_collections.community.network.tests.unit.plugins.modules.utils import set_module_args
+from .edgeswitch_module import TestEdgeswitchModule, load_fixture
+
+
+class TestEdgeswitchConfigModule(TestEdgeswitchModule):
+
+    module = edgeswitch_config
+
+    def setUp(self):
+        super(TestEdgeswitchConfigModule, self).setUp()
+
+        self.mock_get_config = patch('ansible_collections.community.network.plugins.modules.network.edgeswitch.edgeswitch_config.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible_collections.community.network.plugins.modules.network.edgeswitch.edgeswitch_config.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_run_commands = patch('ansible_collections.community.network.plugins.modules.network.edgeswitch.edgeswitch_config.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        super(TestEdgeswitchConfigModule, self).tearDown()
+
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        config_file = 'edgeswitch_config_config.cfg'
+        self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_edgeswitch_config_unchanged(self):
+        src = load_fixture('edgeswitch_config_config.cfg')
+        set_module_args(dict(src=src))
+        self.execute_module()
+
+    def test_edgeswitch_config_src(self):
+        src = load_fixture('edgeswitch_config_src.cfg')
+        set_module_args(dict(src=src))
+        commands = ['domain-name foo',
+                    'interface 0/1',
+                    'no ip address']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_edgeswitch_config_backup(self):
+        set_module_args(dict(backup=True))
+        result = self.execute_module()
+        self.assertIn('__backup__', result)
+
+    def test_edgeswitch_config_save_always(self):
+        self.run_commands.return_value = "domain-name foo"
+        set_module_args(dict(save_when='always'))
+        self.execute_module(changed=True)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('write memory', args['command'])
+
+    def test_edgeswitch_config_save_changed_true(self):
+        src = load_fixture('edgeswitch_config_src.cfg')
+        set_module_args(dict(src=src, save_when='changed'))
+        commands = ['domain-name foo',
+                    'interface 0/1',
+                    'no ip address']
+        self.execute_module(changed=True, commands=commands)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 1)
+        self.assertEqual(self.load_config.call_count, 1)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('write memory', args['command'])
+
+    def test_edgeswitch_config_save_changed_false(self):
+        set_module_args(dict(save_when='changed'))
+        self.execute_module(changed=False)
+        self.assertEqual(self.run_commands.call_count, 0)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+
+    def test_edgeswitch_config_lines_wo_parents(self):
+        set_module_args(dict(lines=['domain-name foo']))
+        commands = ['domain-name foo']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_edgeswitch_config_lines_w_parents(self):
+        set_module_args(dict(lines=['shutdown'], parents=['interface 0/1']))
+        commands = ['interface 0/1', 'shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_edgeswitch_config_before(self):
+        set_module_args(dict(lines=['domain-name foo'], before=['test1', 'test2']))
+        commands = ['test1', 'test2', 'domain-name foo']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_edgeswitch_config_after(self):
+        set_module_args(dict(lines=['domain-name foo'], after=['test1', 'test2']))
+        commands = ['domain-name foo', 'test1', 'test2']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_edgeswitch_config_before_after_no_change(self):
+        set_module_args(dict(lines=['domain-name bar'],
+                             before=['test1', 'test2'],
+                             after=['test3', 'test4']))
+        self.execute_module()
+
+    def test_edgeswitch_config_config(self):
+        config = 'domain-name example.ede'
+        set_module_args(dict(lines=['domain-name bar'], config=config))
+        commands = ['domain-name bar']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_edgeswitch_config_replace_block(self):
+        lines = ['description test-string', 'test-string']
+        parents = ['interface 0/1']
+        set_module_args(dict(lines=lines, replace='block', parents=parents))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands)
+
+    def test_edgeswitch_config_force(self):
+        lines = ['domain-name bar']
+        set_module_args(dict(lines=lines, match='none'))
+        self.execute_module(changed=True, commands=lines)
+
+    def test_edgeswitch_config_match_none(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test-string']
+        parents = ['interface 0/1']
+        set_module_args(dict(lines=lines, parents=parents, match='none'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_edgeswitch_config_match_strict(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test-string',
+                 'shutdown']
+        parents = ['interface 0/1']
+        set_module_args(dict(lines=lines, parents=parents, match='strict'))
+        commands = parents + ['shutdown']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_edgeswitch_config_match_exact(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test-string',
+                 'shutdown']
+        parents = ['interface 0/1']
+        set_module_args(dict(lines=lines, parents=parents, match='exact'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for running commands on and configuring Ubiquiti Edgeswitch devices. These modules were modeled after edgeos_command and aruba_config modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
edgeswitch_command
edgeswitch_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
These are my first modules, if there is anything additional I need to do or change, feel free to say.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
