### PR TITLE
check_running_config set False

### DIFF
--- a/plugins/modules/network/icx/icx_static_route.py
+++ b/plugins/modules/network/icx/icx_static_route.py
@@ -62,7 +62,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-           Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
+           Module will use environment variable value(default:False), unless it is overridden, by specifying it as module parameter.
         type: bool
   purge:
     description:
@@ -78,9 +78,9 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
+       Module will use environment variable value(default:False), unless it is overridden, by specifying it as module parameter.
     type: bool
-    default: yes
+    default: no
 '''
 
 EXAMPLES = """
@@ -258,7 +258,7 @@ def main():
         next_hop=dict(type='str'),
         admin_distance=dict(type='int'),
         state=dict(default='present', choices=['present', 'absent']),
-        check_running_config=dict(default=True, type='bool', fallback=(env_fallback, ['ANSIBLE_CHECK_ICX_RUNNING_CONFIG']))
+        check_running_config=dict(default=False, type='bool', fallback=(env_fallback, ['ANSIBLE_CHECK_ICX_RUNNING_CONFIG']))
     )
 
     aggregate_spec = deepcopy(element_spec)


### PR DESCRIPTION
##### SUMMARY
Manage static IP routes on Ruckus ICX switches.
setting check_running_config to False

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Module Name: icx_static_route.py

##### ADDITIONAL INFORMATION
1. ip  route prefix next_hop [distance number]
2. no ip  route prefix next_hop [distance number]
