### PR TITLE
feat(edgeos_config): Append save command into result

### DIFF
--- a/changelogs/fragments/189-append-save-command-into-result.yaml
+++ b/changelogs/fragments/189-append-save-command-into-result.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - community.network.edgeos_config - append save command into result (https://github.com/ansible-collections/community.network/pull/189)

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -305,7 +305,7 @@ def main():
         diff = run_commands(module, commands=['configure', 'compare saved'])[1]
         if diff != '[edit]':
             if 'commands' in result:
-              result['commands'].append('save')
+                result['commands'].append('save')
             if not module.check_mode:
                 run_commands(module, commands=['save'])
             result['changed'] = True

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -304,6 +304,8 @@ def main():
     if module.params['save']:
         diff = run_commands(module, commands=['configure', 'compare saved'])[1]
         if diff != '[edit]':
+            if 'commands' in result:
+              result['commands'].append('save')
             if not module.check_mode:
                 run_commands(module, commands=['save'])
             result['changed'] = True


### PR DESCRIPTION
##### SUMMARY

Add "save" command into the "commands" array of the task results. Usefull when only a save is required and the task appear to be "changed: true" without any commands or diff (refer to #184 )

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
Before

```
TASK [Configure base settings] ************************************************************************************************************************************************************************************
changed: [net-rtr01-p01] => {"changed": true, "commands": []}

TASK [Configure firewall] *****************************************************************************************************************************************************************************************
ok: [net-rtr01-p01.dc01] => {"changed": false, "commands": []}

```

After

```
TASK [Configure base settings] ************************************************************************************************************************************************************************************
changed: [net-rtr01-p01] => {"changed": true, "commands": ["save"]}

TASK [Configure firewall] *****************************************************************************************************************************************************************************************
ok: [net-rtr01-p01] => {"changed": false, "commands": []}

```
