### PR TITLE
Small edgeos_config improvements

### DIFF
--- a/changelogs/fragments/199-edgeos-improvements.yaml
+++ b/changelogs/fragments/199-edgeos-improvements.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- edgeos_config - match the space after "set" and "delete" commands (https://github.com/ansible-collections/community.network/pull/199)
+- edgeos_config - match the space after ``set`` and ``delete`` commands (https://github.com/ansible-collections/community.network/pull/199).

--- a/changelogs/fragments/199-edgeos-improvements.yaml
+++ b/changelogs/fragments/199-edgeos-improvements.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- edgeos_config - match the space after "set" and "delete" commands (https://github.com/ansible-collections/community.network/pull/199)

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -209,10 +209,7 @@ def diff_config(module, commands, config):
     for line in commands:
         item = to_native(check_command(module, line))
 
-        if not item.startswith(SET_CMD) and not item.startswith(DELETE_CMD):
-            raise ValueError('line must start with either `set` or `delete`')
-
-        elif item.startswith(SET_CMD):
+        if item.startswith(SET_CMD):
 
             if item not in config:
                 updates.append(line)
@@ -234,6 +231,9 @@ def diff_config(module, commands, config):
                     if entry.startswith(item) and line not in visited:
                         updates.append(line)
                         visited.add(line)
+
+        else:
+            raise ValueError('line must start with either `set` or `delete`')
 
     return list(updates)
 

--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -138,8 +138,6 @@ backup_path:
   sample: /playbooks/ansible/backup/edgeos_config.2016-07-16@22:28:34
 """
 
-import re
-
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import NetworkConfig
@@ -222,7 +220,7 @@ def diff_config(module, commands, config):
             # If there is a corresponding delete command in the desired config, make sure to append
             # the set command even though it already exists in the running config
             else:
-                ditem = re.sub(SET_CMD, DELETE_CMD, item)
+                ditem = item.replace(SET_CMD, DELETE_CMD, 1)
                 for line in delete_commands:
                     if ditem.startswith(line):
                         updates.append(item)
@@ -231,7 +229,7 @@ def diff_config(module, commands, config):
             if not config:
                 updates.append(line)
             else:
-                item = re.sub(DELETE_CMD, SET_CMD, item)
+                item = item.replace(DELETE_CMD, SET_CMD, 1)
                 for entry in config:
                     if entry.startswith(item) and line not in visited:
                         updates.append(line)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
* The module was littered with magic strings ("set" and "delete") which were too broad a match (because to be commands, they have to be followed by a space).
* The logical flow to handle when commands started with neither "set" nor "delete" is stated more easily using an "else" block, avoiding duplication of the `.startswith()` checks
* Using regular expressions to replace plain strings is overkill

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

(not really, just cleanup)

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
edgeos_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
