### PR TITLE
fixed: variable 'rsp' referenced before assignment

### DIFF
--- a/plugins/modules/network/avi/avi_useraccount.py
+++ b/plugins/modules/network/avi/avi_useraccount.py
@@ -120,6 +120,7 @@ def main():
         first_pwd = api_creds.password
         second_pwd = old_password
     password_changed = False
+    rsp = None
     try:
         api = ApiSession.get_session(
             api_creds.controller, api_creds.username,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The following task is not idempotent:
```- name: Set Admin Password
    community.network.avi_useraccount:
      avi_credentials: "{{ avi_credentials }}"
      old_password: "{{ avi_default_password }}"
      force_change: True
      password: "{{ avi_password }}"
      username: "{{ avi_username }}"
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


On the first run it completes successfully, but subsequent runs result in the following error:
```
line 148, in main\nUnboundLocalError: local variable 'rsp' referenced before assignment\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.network.avi_useraccount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Run this task more than once in succession:
```- name: Set Admin Password
    community.network.avi_useraccount:
      avi_credentials: "{{ avi_credentials }}"
      old_password: "{{ avi_default_password }}"
      force_change: True
      password: "{{ avi_password }}"
      username: "{{ avi_username }}"
```

After a successful first run, subsequent runs will fail.

Before:
```
TASK [Set Admin Password] ******************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "/home/vagrant/.venv/lib64/python3.6/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host '10.xxx.xxx.xxx'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings\n  InsecureRequestWarning,\nStatus Code 401 msg {\"error\": \"Invalid credentials\"}\n/home/vagrant/.venv/lib64/python3.6/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host '10.xxx.xxx.xxx'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings\n  InsecureRequestWarning,\nTraceback (most recent call last):\n  File \"/home/vagrant/.ansible/tmp/ansible-tmp-1613701146.246441-11203-84759223293469/AnsiballZ_avi_useraccount.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/home/vagrant/.ansible/tmp/ansible-tmp-1613701146.246441-11203-84759223293469/AnsiballZ_avi_useraccount.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/vagrant/.ansible/tmp/ansible-tmp-1613701146.246441-11203-84759223293469/AnsiballZ_avi_useraccount.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.network.plugins.modules.avi_useraccount', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.network.avi_useraccount_payload_tjd3xypl/ansible_community.network.avi_useraccount_payload.zip/ansible_collections/community/network/plugins/modules/avi_useraccount.py\", line 152, in <module>\n  File \"/tmp/ansible_community.network.avi_useraccount_payload_tjd3xypl/ansible_community.network.avi_useraccount_payload.zip/ansible_collections/community/network/plugins/modules/avi_useraccount.py\", line 148, in main\nUnboundLocalError: local variable 'rsp' referenced before assignment\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

After:
```
TASK [Set Admin Password] ******************************************************************************************************************
ok: [localhost]
```
