### PR TITLE
nclu: fix 'net pending' delimiter string, and exec commit only if changed

### DIFF
--- a/changelogs/fragments/219-nclu-fix-pending.yaml
+++ b/changelogs/fragments/219-nclu-fix-pending.yaml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - nclu - fix `net pending` delimiter string (https://github.com/ansible-collections/community.network/pull/219)
+  - nclu - fix ``net pending`` delimiter string (https://github.com/ansible-collections/community.network/pull/219).
 minor_changes:
   - nclu - execute `net commit description <description>` only if changed `net pending`'s diff field (https://github.com/ansible-collections/community.network/pull/219)

--- a/changelogs/fragments/219-nclu-fix-pending.yaml
+++ b/changelogs/fragments/219-nclu-fix-pending.yaml
@@ -2,4 +2,4 @@
 bugfixes:
   - nclu - fix ``net pending`` delimiter string (https://github.com/ansible-collections/community.network/pull/219).
 minor_changes:
-  - nclu - execute `net commit description <description>` only if changed `net pending`'s diff field (https://github.com/ansible-collections/community.network/pull/219)
+  - nclu - execute ``net commit description <description>`` only if changed ``net pending``'s diff field (https://github.com/ansible-collections/community.network/pull/219).

--- a/changelogs/fragments/219-nclu-fix-pending.yaml
+++ b/changelogs/fragments/219-nclu-fix-pending.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nclu - fix `net pending` delimiter string (https://github.com/ansible-collections/community.network/pull/219)
+minor_changes:
+  - nclu - execute `net commit description <description>` only if changed `net pending`'s diff field (https://github.com/ansible-collections/community.network/pull/219)

--- a/plugins/modules/network/cumulus/nclu.py
+++ b/plugins/modules/network/cumulus/nclu.py
@@ -165,7 +165,7 @@ def check_pending(module):
     """Check the pending diff of the nclu buffer."""
     pending = command_helper(module, "pending", "Error in pending config. You may want to view `net pending` on this target.")
 
-    delimeter1 = "net add/del commands since the last 'net commit'"
+    delimeter1 = "net add/del commands since the last \"net commit\""
     color1 = '\x1b[94m'
     if delimeter1 in pending:
         pending = pending.split(delimeter1)[0]
@@ -209,13 +209,15 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
         _changed = True
 
     # Do the commit.
-    if do_commit:
+    if (do_commit and _changed):
         result = command_helper(module, "commit description '%s'" % description)
         if "commit ignored" in result:
             _changed = False
             command_helper(module, "abort")
         elif command_helper(module, "show commit last") == "":
             _changed = False
+    elif do_abort:
+        command_helper(module, "abort")
 
     return _changed, output
 

--- a/tests/unit/plugins/modules/network/cumulus/test_nclu.py
+++ b/tests/unit/plugins/modules/network/cumulus/test_nclu.py
@@ -217,8 +217,7 @@ class TestNclu(unittest.TestCase):
         changed, output = nclu.run_nclu(module, None, None, True, False, False, "ignore me")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
-                                                  '/usr/bin/net pending',
-                                                  '/usr/bin/net abort'])
+                                                  '/usr/bin/net pending'])
         self.assertEqual(len(module.pending), 0)
         self.assertEqual(module.fail_code, {})
         self.assertEqual(changed, False)

--- a/tests/unit/plugins/modules/network/cumulus/test_nclu.py
+++ b/tests/unit/plugins/modules/network/cumulus/test_nclu.py
@@ -218,7 +218,6 @@ class TestNclu(unittest.TestCase):
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net pending',
-                                                  "/usr/bin/net commit description 'ignore me'",
                                                   '/usr/bin/net abort'])
         self.assertEqual(len(module.pending), 0)
         self.assertEqual(module.fail_code, {})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- mod `nclu` module
    - fixed `net pending` 's delimiter string
        - checked version : `3.7.3`, `4.0.0`, `4.2.1`, `4.3.0`
    - execute `net commit description <description>` only if changed `net pending`'s diff field.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`nclu`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
