### PR TITLE
CI fixes

### DIFF
--- a/changelogs/fragments/228-static_route-devel.yml
+++ b/changelogs/fragments/228-static_route-devel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "{cnos,icx}_static_route modules - fix modules to work with ansible-core 2.11 (https://github.com/ansible-collections/community.network/pull/228)."

--- a/plugins/modules/network/cnos/cnos_static_route.py
+++ b/plugins/modules/network/cnos/cnos_static_route.py
@@ -113,6 +113,7 @@ commands:
 from copy import deepcopy
 from re import findall
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.validation import check_required_together
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import validate_ip_address
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import remove_default_spec
 from ansible_collections.community.network.plugins.module_utils.network.cnos.cnos import get_config, load_config
@@ -218,10 +219,10 @@ def map_params_to_obj(module, required_together=None):
                     route[key] = module.params.get(key)
 
             route = dict((k, v) for k, v in route.items() if v is not None)
-            module._check_required_together(required_together, route)
+            check_required_together(required_together, route)
             obj.append(route)
     else:
-        module._check_required_together(required_together, module.params)
+        check_required_together(required_together, module.params)
         route = dict()
         for key in keys:
             if module.params.get(key) is not None:

--- a/plugins/modules/network/icx/icx_static_route.py
+++ b/plugins/modules/network/icx/icx_static_route.py
@@ -125,6 +125,7 @@ import re
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.common.validation import check_required_together
 from ansible.module_utils.connection import ConnectionError
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import remove_default_spec
 from ansible_collections.community.network.plugins.module_utils.network.icx.icx import get_config, load_config
@@ -224,14 +225,14 @@ def map_params_to_obj(module, required_together=None):
                 if route.get(key) is None:
                     route[key] = module.params.get(key)
 
-            module._check_required_together(required_together, route)
+            check_required_together(required_together, route)
 
             prefix, mask = prefix_length_parser(route['prefix'], route['mask'], module)
             route.update({'prefix': prefix, 'mask': mask})
 
             obj.append(route)
     else:
-        module._check_required_together(required_together, module.params)
+        check_required_together(required_together, module.params)
         prefix, mask = prefix_length_parser(module.params['prefix'], module.params['mask'], module)
 
         obj.append({

--- a/tests/unit/plugins/modules/network/slxos/test_slxos_interface.py
+++ b/tests/unit/plugins/modules/network/slxos/test_slxos_interface.py
@@ -147,9 +147,7 @@ class TestSlxosInterfaceModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
-            'shawshank Supported parameters include: aggregate, '
-            'delay, description, enabled, mtu, name, neighbors, '
-            'rx_rate, speed, state, tx_rate',
+            r'Unsupported parameters for \(basic\.pyc?\) module: shawshank\.? '
+            'Supported parameters include: .+',
             result['msg']
         ))

--- a/tests/unit/plugins/modules/network/slxos/test_slxos_l2_interface.py
+++ b/tests/unit/plugins/modules/network/slxos/test_slxos_l2_interface.py
@@ -164,9 +164,7 @@ class TestSlxosL2InterfaceModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
-            'shawshank Supported parameters include: access_vlan, aggregate, '
-            r'mode, name( \(interface\))?, native_vlan, state, '
-            'trunk_allowed_vlans, trunk_vlans',
+            r'Unsupported parameters for \(basic\.pyc?\) module: shawshank\.? '
+            'Supported parameters include: .+',
             result['msg']
         ))

--- a/tests/unit/plugins/modules/network/slxos/test_slxos_l3_interface.py
+++ b/tests/unit/plugins/modules/network/slxos/test_slxos_l3_interface.py
@@ -95,8 +95,7 @@ class TestSlxosL3InterfaceModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
-            'shawshank Supported parameters include: aggregate, ipv4, ipv6, '
-            'name, state',
+            r'Unsupported parameters for \(basic\.pyc?\) module: shawshank\.? '
+            'Supported parameters include: .+',
             result['msg']
         ))

--- a/tests/unit/plugins/modules/network/slxos/test_slxos_linkagg.py
+++ b/tests/unit/plugins/modules/network/slxos/test_slxos_linkagg.py
@@ -152,8 +152,7 @@ class TestSlxosLinkaggModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.pyc|basic.py)\) module: '
-            'shawshank Supported parameters include: aggregate, group, '
-            'members, mode, purge, state',
+            r'Unsupported parameters for \(basic\.pyc?\) module: shawshank\.? '
+            'Supported parameters include: .+',
             result['msg']
         ))

--- a/tests/unit/plugins/modules/network/slxos/test_slxos_lldp.py
+++ b/tests/unit/plugins/modules/network/slxos/test_slxos_lldp.py
@@ -89,7 +89,7 @@ class TestSlxosLldpModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
-            'shawshank Supported parameters include: state',
+            r'Unsupported parameters for \(basic\.pyc?\) module: shawshank\.? '
+            'Supported parameters include: .+',
             result['msg']
         ), 'Output did not match. Got: %s' % result['msg'])

--- a/tests/unit/plugins/modules/network/slxos/test_slxos_vlan.py
+++ b/tests/unit/plugins/modules/network/slxos/test_slxos_vlan.py
@@ -137,8 +137,12 @@ class TestSlxosVlanModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
-            'shawshank Supported parameters include: aggregate, delay, '
-            'interfaces, name, purge, state, vlan_id',
+            '(?:'
+            # < ansible-core 2.11
+            r'Unsupported parameters for \(basic\.pyc?\) module: shawshank\.? Supported parameters include: .+'
+            '|'
+            # >= ansible-core 2.11
+            'one of the following is required: .+'
+            ')',
             result['msg']
         ), 'Result did not match expected output. Got: %s' % result['msg'])


### PR DESCRIPTION
##### SUMMARY
CI fixes around https://github.com/ansible/ansible/pull/73703.

- switched to public common validation methods:
  - plugins/modules/network/cnos/cnos_static_route.py
  - plugins/modules/network/icx/icx_static_route.py
- fixed / simplified regex matching:
  - tests/unit/plugins/modules/network/slxos/test_slxos_interface.py
  - tests/unit/plugins/modules/network/slxos/test_slxos_l2_interface.py
  - tests/unit/plugins/modules/network/slxos/test_slxos_l3_interface.py
  - tests/unit/plugins/modules/network/slxos/test_slxos_linkagg.py
  - tests/unit/plugins/modules/network/slxos/test_slxos_lldp.py
  - tests/unit/plugins/modules/network/slxos/test_slxos_vlan.py

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- plugins/modules/network/cnos/cnos_static_route.py
- plugins/modules/network/icx/icx_static_route.py
- tests/unit/plugins/modules/network/slxos/test_slxos_interface.py
- tests/unit/plugins/modules/network/slxos/test_slxos_l2_interface.py
- tests/unit/plugins/modules/network/slxos/test_slxos_l3_interface.py
- tests/unit/plugins/modules/network/slxos/test_slxos_linkagg.py
- tests/unit/plugins/modules/network/slxos/test_slxos_lldp.py
- tests/unit/plugins/modules/network/slxos/test_slxos_vlan.py