### PR TITLE
Don't rely on safe_eval being able to do math/concat

### DIFF
--- a/changelogs/fragments/289-safe-eval-no-concat.yml
+++ b/changelogs/fragments/289-safe-eval-no-concat.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - Don't rely on ``safe_eval`` being able to do math/concat
+    (https://github.com/ansible-collections/community.network/pull/289)

--- a/tests/integration/targets/cnos_system/tasks/cli.yaml
+++ b/tests/integration/targets/cnos_system/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: "{{ test_cases.files }} + {{ cli_cases.files }}"
+      files: "{{ test_cases.files + cli_cases.files }}"
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/cnos_user/tasks/cli.yaml
+++ b/tests/integration/targets/cnos_user/tasks/cli.yaml
@@ -15,7 +15,7 @@
 
 - set_fact:
     test_cases:
-      files: "{{ test_cases.files }} + {{ cli_cases.files }}"
+      files: "{{ test_cases.files + cli_cases.files }}"
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/exos_l2_interfaces/tests/httpapi/deleted.yaml
+++ b/tests/integration/targets/exos_l2_interfaces/tests/httpapi/deleted.yaml
@@ -89,7 +89,7 @@
         - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.before) == []"
 
   - set_fact:
-      expected_config: "{{ config }} + {{ config_all }}"
+      expected_config: "{{ config + config_all }}"
 
   - assert:
       that:

--- a/tests/integration/targets/exos_l2_interfaces/tests/httpapi/overridden.yaml
+++ b/tests/integration/targets/exos_l2_interfaces/tests/httpapi/overridden.yaml
@@ -51,7 +51,7 @@
         - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.after) == []"
 
   - set_fact:
-      expected_config: "{{ config }} + {{ config_all }}"
+      expected_config: "{{ config + config_all }}"
 
   - assert:
       that:

--- a/tests/integration/targets/exos_lldp_interfaces/tests/httpapi/deleted.yaml
+++ b/tests/integration/targets/exos_lldp_interfaces/tests/httpapi/deleted.yaml
@@ -84,7 +84,7 @@
         - "ansible_facts.network_resources.lldp_interfaces|symmetric_difference(result.before) == []"
 
   - set_fact:
-      expected_config: "{{ config }} + {{ config_all }}"
+      expected_config: "{{ config + config_all }}"
 
   - assert:
       that:


### PR DESCRIPTION
##### SUMMARY
Don't rely on `safe_eval` being able to do math/concat. This functionality will be removed in ansible-core 2.12, and has never worked with jinja2 native which we are working toward making the default in 2.12.

See https://github.com/ansible/ansible/pull/75068

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
