### PR TITLE
added 'unsupported' alias to failing integration tests that do not have simulators

### DIFF
--- a/tests/integration/targets/ce_is_is_instance/aliases
+++ b/tests/integration/targets/ce_is_is_instance/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_is_is_interface/aliases
+++ b/tests/integration/targets/ce_is_is_interface/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_is_is_view/aliases
+++ b/tests/integration/targets/ce_is_is_view/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_lacp/aliases
+++ b/tests/integration/targets/ce_lacp/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_lldp/aliases
+++ b/tests/integration/targets/ce_lldp/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_lldp_interface/aliases
+++ b/tests/integration/targets/ce_lldp_interface/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_mdn_interface/aliases
+++ b/tests/integration/targets/ce_mdn_interface/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_multicast_global/aliases
+++ b/tests/integration/targets/ce_multicast_global/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_multicast_igmp_enable/aliases
+++ b/tests/integration/targets/ce_multicast_igmp_enable/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ce_static_route_bfd/aliases
+++ b/tests/integration/targets/ce_static_route_bfd/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_command/aliases
+++ b/tests/integration/targets/exos_command/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_config/aliases
+++ b/tests/integration/targets/exos_config/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_facts/aliases
+++ b/tests/integration/targets/exos_facts/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_l2_interfaces/aliases
+++ b/tests/integration/targets/exos_l2_interfaces/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_lldp_global/aliases
+++ b/tests/integration/targets/exos_lldp_global/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_lldp_interfaces/aliases
+++ b/tests/integration/targets/exos_lldp_interfaces/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/exos_vlans/aliases
+++ b/tests/integration/targets/exos_vlans/aliases
@@ -1,0 +1,1 @@
+unsupported


### PR DESCRIPTION
##### SUMMARY
Several integration tests were missing `aliases` files, in particular they were missing `unsupported` in those `aliases` files. This resulted in the default `ansible-test integration ...` command running (and failing) different tests than CI. This PR addresses that, resulting in the default `ansible-test integration ...` command running the same list of tests as the `shippable/cloud/group1/` target.

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
- CI

##### ADDITIONAL INFORMATION
N/A