### PR TITLE
galaxy.yml: exclude non-collection files from collection build

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,3 +14,11 @@ repository: https://github.com/ansible-collections/community.network
 documentation: https://docs.ansible.com/ansible/latest/collections/community/network/
 homepage: https://github.com/ansible-collections/community.network
 issues: https://github.com/ansible-collections/community.network/issues
+build_ignore:
+  - .azure-pipelines
+  - .github
+  - .gitignore
+  - changelogs
+  - CONTRIBUTING.md
+  - shippable.yml
+  - tests


### PR DESCRIPTION
##### SUMMARY
Files that belong to the git repository such as git, github and
azure pipeline configuration should not be included in the published
collection tarball.

Excluding tests saves on what makes the bulk of the size of the
collection, both in size and number of files.

In aggregate, excluding these files results in a meaningful improvement
which will speed up the installation of the collection and reduce the
size on disk.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
### Before
```
> du -sh community-network-3.0.0.tar.gz 
1.6M community-network-3.0.0.tar.gz

> du -sh community.network
15M community.network

> find . -type f | wc -l
1335

> time ansible-galaxy collection install /tmp/community-network-3.0.0.tar.gz 
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'community.network:3.0.0' to '/home/dmsimard/.ansible/collections/ansible_collections/community/network'
Downloading https://galaxy.ansible.com/download/ansible-netcommon-2.4.0.tar.gz to /home/dmsimard/.ansible/tmp/ansible-local-266950_ght6xwq/tmp4dcbu964/ansible-netcommon-2.4.0-0j5l9qkn
community.network:3.0.0 was installed successfully
Installing 'ansible.netcommon:2.4.0' to '/home/dmsimard/.ansible/collections/ansible_collections/ansible/netcommon'
Downloading https://galaxy.ansible.com/download/ansible-utils-2.4.1.tar.gz to /home/dmsimard/.ansible/tmp/ansible-local-266950_ght6xwq/tmp4dcbu964/ansible-utils-2.4.1-qub1vjk2
ansible.netcommon:2.4.0 was installed successfully
Installing 'ansible.utils:2.4.1' to '/home/dmsimard/.ansible/collections/ansible_collections/ansible/utils'
ansible.utils:2.4.1 was installed successfully

________________________________________________________
Executed in   14.07 secs    fish           external
   usr time    4.57 secs    0.00 micros    4.57 secs
   sys time    0.27 secs  574.00 micros    0.27 secs
```

### After
```
> du -sh community-network-3.1.0.tar.gz 
904K	community-network-3.1.0.tar.gz

> du -sh community.network
6.5M	community.network

> find . -type f | wc -l
494

> time ansible-galaxy collection install /tmp/community-network-3.1.0.tar.gz 
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'community.network:3.1.0' to '/home/dmsimard/.ansible/collections/ansible_collections/community/network'
Downloading https://galaxy.ansible.com/download/ansible-netcommon-2.4.0.tar.gz to /home/dmsimard/.ansible/tmp/ansible-local-267338vr2g7_ad/tmpabbtqoq0/ansible-netcommon-2.4.0-yhyhxfsi
community.network:3.1.0 was installed successfully
Installing 'ansible.netcommon:2.4.0' to '/home/dmsimard/.ansible/collections/ansible_collections/ansible/netcommon'
Downloading https://galaxy.ansible.com/download/ansible-utils-2.4.1.tar.gz to /home/dmsimard/.ansible/tmp/ansible-local-267338vr2g7_ad/tmpabbtqoq0/ansible-utils-2.4.1-al5rf48x
ansible.netcommon:2.4.0 was installed successfully
Installing 'ansible.utils:2.4.1' to '/home/dmsimard/.ansible/collections/ansible_collections/ansible/utils'
ansible.utils:2.4.1 was installed successfully

________________________________________________________
Executed in    4.73 secs    fish           external
   usr time    2.91 secs  487.00 micros    2.91 secs
   sys time    0.19 secs  178.00 micros    0.19 secs
```