### PR TITLE
Add support decode bitmap for ce_switchport module

### DIFF
--- a/changelogs/fragments/315_add_support_decode_bitmap_for_ce_switchport_module.yaml
+++ b/changelogs/fragments/315_add_support_decode_bitmap_for_ce_switchport_module.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - community.network.ce_switchport - add support of decode a few stdout values from bitmap to
+    human readable format(https://github.com/ansible-collections/community.network/issues/315)

--- a/plugins/modules/network/cloudengine/ce_switchport.py
+++ b/plugins/modules/network/cloudengine/ce_switchport.py
@@ -759,6 +759,28 @@ class SwitchPort(object):
 
         return vlan_xml
 
+    def bitmap_to_vlan_list(self, bitmap):
+        """convert VLAN bitmap to VLAN list"""
+
+        vlan_list = list()
+        if not bitmap:
+            return vlan_list
+
+        for i in range(len(bitmap)):
+            if bitmap[i] == '0':
+                continue
+            bit = int(bitmap[i], 16)
+            if bit & 0x8:
+                vlan_list.append(str(i * 4))
+            if bit & 0x4:
+                vlan_list.append(str(i * 4 + 1))
+            if bit & 0x2:
+                vlan_list.append(str(i * 4 + 2))
+            if bit & 0x1:
+                vlan_list.append(str(i * 4 + 3))
+
+        return vlan_list
+
     def vlan_bitmap_add(self, oldmap, newmap):
         """vlan add bitmap"""
 
@@ -891,11 +913,11 @@ class SwitchPort(object):
                 self.existing['access_pvid'] = self.intf_info["pvid"]
             elif self.intf_info["linkType"] == "trunk":
                 self.existing['trunk_pvid'] = self.intf_info["pvid"]
-                self.existing['trunk_vlans'] = self.intf_info["trunkVlans"]
+                self.existing['trunk_vlans'] = self.bitmap_to_vlan_list(self.intf_info["trunkVlans"])
             elif self.intf_info["linkType"] == "hybrid":
                 self.existing['hybrid_pvid'] = self.intf_info["pvid"]
                 self.existing['hybrid_untagged_vlans'] = self.intf_info["untagVlans"]
-                self.existing['hybrid_tagged_vlans'] = self.intf_info["trunkVlans"]
+                self.existing['hybrid_tagged_vlans'] = self.bitmap_to_vlan_list(self.intf_info["trunkVlans"])
             else:
                 self.existing['dot1qtunnel_pvid'] = self.intf_info["pvid"]
 
@@ -911,11 +933,11 @@ class SwitchPort(object):
                 self.end_state['access_pvid'] = end_info["pvid"]
             elif end_info["linkType"] == "trunk":
                 self.end_state['trunk_pvid'] = end_info["pvid"]
-                self.end_state['trunk_vlans'] = end_info["trunkVlans"]
+                self.end_state['trunk_vlans'] = self.bitmap_to_vlan_list(end_info["trunkVlans"])
             elif end_info["linkType"] == "hybrid":
                 self.end_state['hybrid_pvid'] = end_info["pvid"]
                 self.end_state['hybrid_untagged_vlans'] = end_info["untagVlans"]
-                self.end_state['hybrid_tagged_vlans'] = end_info["trunkVlans"]
+                self.end_state['hybrid_tagged_vlans'] = self.bitmap_to_vlan_list(end_info["trunkVlans"])
             else:
                 self.end_state['dot1qtunnel_pvid'] = end_info["pvid"]
         if self.end_state == self.existing:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support decode bitmap few values, that was in bitmap format.
This makes possible to see difference between `end_state` and `proposal`

Fixes #315
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
community.network.ce_switchport

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- hosts: sw
  gather_facts: false
  vars:
    ansible_connection: ansible.netcommon.netconf
    ansible_user: root
    ansible_password: PASSWD
    ce__create_vlan: 3000

  tasks:
    - name: Create vlans to {{ inventory_hostname }}
      community.network.ce_vlan:
        vlan_id: "{{ ce__create_vlan }}"
        state: present

    - name: Test ce_switchport
      community.network.ce_switchport:
        interface: "40GE2/1/1"
        mode: trunk
        trunk_vlans: "{{ ce__create_vlan }}"
```
```bash
$ ansible-playbook -i inventory.yml playbook.yml -vvv
...
TASK [Create vlans to 10.10.10.10] ********************************************************************************************************************************
ok: [10.10.10.10]

TASK [Test ce_switchport] *******************************************************************************************************************************************
ok: [10.10.10.10] => {
    "changed": false,
    "end_state": {
        "interface": "40GE2/1/1",
        "mode": "trunk",
        "switchport": "enable",
        "trunk_pvid": "1",
        "trunk_vlans": [
            "3000",
        ]
    },
    "existing": {
        "interface": "40GE2/1/1",
        "mode": "trunk",
        "switchport": "enable",
        "trunk_pvid": "1",
        "trunk_vlans": [
            "3000",
        ]
    },
    "invocation": {
        "module_args": {
            "default_vlan": null,
            "interface": "40GE2/1/1",
            "mode": "trunk",
            "provider": null,
            "pvid_vlan": null,
            "state": "present",
            "tagged_vlans": null,
            "trunk_vlans": "3000",
            "untagged_vlans": null
        }
    },
    "proposed": {
        "interface": "40GE2/1/1",
        "mode": "trunk",
        "pvid_vlan": null,
        "state": "present",
        "trunk_vlans": "3000"
    },
    "updates": []
}

PLAY RECAP **********************************************************************************************************************************************************
10.10.10.10              : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
From log above we can see, that `trunk_vlans` in `existing` and `end_state` in human readable format

