### PR TITLE
Install older version of check_point.mgmt for CI only

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ tags: [community, network]
 # NOTE: No more dependencies can be added to this list
 dependencies:
   ansible.netcommon: '>=1.0.0,<2.0.0'
-  check_point.mgmt: '>=1.0.0,<2.1.0'
+  check_point.mgmt: '>=1.0.0'
   fortinet.fortios: '>=1.0.0'
 repository: https://github.com/ansible-collections/community.network
 documentation: https://docs.ansible.com/ansible/latest/collections/community/network/


### PR DESCRIPTION
##### SUMMARY
Newer versions of `check_point.mgmt` requires Ansible 2.10 (or higher), so use an older version of the collection

##### ISSUE TYPE
- Bugfix Pull Request
