### PR TITLE
Enable ansibullbot notifications in issues and PRs

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1,4 +1,5 @@
 automerge: false
+notifications: true
 files:
   $actions/aireos.py:
     labels: aireos cisco networking


### PR DESCRIPTION
##### SUMMARY
The more recent version of Ansibullbot defaults notifications to false.
We need to set it to true so it can notify contributors and maintainers.

Copy of https://github.com/ansible-collections/community.general/pull/3462.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- BOTMETA
