### PR TITLE
removed unnecessary requirement

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -9,6 +9,3 @@ pyFMG
 # requirements for Nuage modules  - CURRENTLY BROKEN!
 # vspk
 # bambou
-
-# requirements for routeros_api module
-librouteros<3.2.0 ; python_version >= '3.6'


### PR DESCRIPTION
##### SUMMARY
`librouteros` requirement is no longer needed

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- CI