### PR TITLE
removed unnecessary FortiOS requirements

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -3,9 +3,6 @@ unittest2 ; python_version <= '2.6'
 # requirements for ftd module_utils
 firepower-kickstart ; python_version >= '3.6' and python_version < '3.9'  # Python 3.6+ only; dependency does not work with 3.9 yet
 
-# requirements for FortiManager modules
-pyFMG
-
 # requirements for Nuage modules  - CURRENTLY BROKEN!
 # vspk
 # bambou

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -27,7 +27,6 @@ openshift >= 0.6.2, < 0.9.0 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pathspec < 0.6.0 ; python_version < '2.7' # pathspec 0.6.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
-pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pyyaml < 5.1 ; python_version < '2.7' # pyyaml 5.1 and later require python 2.7 or later
 pycparser < 2.19 ; python_version < '2.7' # pycparser 2.19 and later require python 2.7 or later
 mock >= 2.0.0 # needed for features backported from Python 3.6 unittest.mock (assert_called, assert_called_once...)

--- a/tests/utils/requirements.txt
+++ b/tests/utils/requirements.txt
@@ -21,9 +21,6 @@ f5-sdk ; python_version >= '2.7'
 f5-icontrol-rest ; python_version >= '2.7'
 deepdiff
 
-# requirement for Fortinet specific modules
-pyFMG
-
 # requirement for aci_rest module
 xmljson
 


### PR DESCRIPTION
##### SUMMARY
`pyFMG` requirement is no longer needed

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- CI