### PR TITLE
[PR #326/b44e7d41 backport][stable-1] declaring type in docs to match argspec

### DIFF
--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -34,6 +34,8 @@ options:
       - The ordered set of configuration lines to be managed and
         compared with the existing configuration on the remote
         device.
+    type: list
+    elements: str
   src:
     description:
       - The C(src) argument specifies the path to the source config
@@ -268,7 +270,7 @@ def main():
     )
     spec = dict(
         src=dict(type='path'),
-        lines=dict(type='list'),
+        lines=dict(type='list', elements='str'),
 
         match=dict(default='line', choices=['line', 'none']),
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -784,7 +784,6 @@ plugins/modules/network/edgeos/edgeos_command.py validate-modules:doc-missing-ty
 plugins/modules/network/edgeos/edgeos_command.py validate-modules:parameter-list-no-elements
 plugins/modules/network/edgeos/edgeos_command.py validate-modules:parameter-type-not-in-doc
 plugins/modules/network/edgeos/edgeos_config.py validate-modules:doc-missing-type
-plugins/modules/network/edgeos/edgeos_config.py validate-modules:parameter-list-no-elements
 plugins/modules/network/edgeos/edgeos_config.py validate-modules:parameter-type-not-in-doc
 plugins/modules/network/edgeos/edgeos_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/network/edgeos/edgeos_facts.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -784,7 +784,6 @@ plugins/modules/network/edgeos/edgeos_command.py validate-modules:doc-missing-ty
 plugins/modules/network/edgeos/edgeos_command.py validate-modules:parameter-list-no-elements
 plugins/modules/network/edgeos/edgeos_command.py validate-modules:parameter-type-not-in-doc
 plugins/modules/network/edgeos/edgeos_config.py validate-modules:doc-missing-type
-plugins/modules/network/edgeos/edgeos_config.py validate-modules:parameter-list-no-elements
 plugins/modules/network/edgeos/edgeos_config.py validate-modules:parameter-type-not-in-doc
 plugins/modules/network/edgeos/edgeos_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/network/edgeos/edgeos_facts.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
**This is a backport of PR #326 as merged into main (b44e7d41af243372cea68f6e6896beeb59ba1a62).**

This is to fix an issue in upstream so it can be backported to 2.9 per @samccann in the [partnering merge request](https://github.com/ansible/ansible/pull/76220#issuecomment-969318633)

From my original MR:
---
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates docs to reflect correct `lines` argument `type` of `list` instead of default `string`.  Verified by [the module itself](https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/modules/network/edgeos/edgeos_config.py#L281)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`edgeos_config` module
##### ADDITIONAL INFORMATION
Causes issues with [SchemaStore](https://github.com/SchemaStore/schemastore/) that gets its ansible schema automatically generated from this repo. SchemaStore is used by the [RedHat VScode-yaml plug-in](https://github.com/redhat-developer/vscode-yaml) which, in turn, is used by the [Ansible VScode module](https://github.com/ansible/vscode-ansible).

First time contributor, so if I'm pointing this in the wrong direction, let me know.  Thanks!
