### PR TITLE
Remove ex scalers from team_scaleway

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -374,4 +374,4 @@ macros:
   team_netscaler: chiradeep giorgos-nikolopoulos
   team_netvisor: Qalthos amitsi csharpe-pn pdam preetiparasar
   team_networking: NilashishC Qalthos danielmellado ganeshrn justjais trishnaguha
-  team_scaleway: abarbare kindermoumoute remyleo
+  team_scaleway: abarbare kindermoumoute remyleone

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -374,4 +374,4 @@ macros:
   team_netscaler: chiradeep giorgos-nikolopoulos
   team_netvisor: Qalthos amitsi csharpe-pn pdam preetiparasar
   team_networking: NilashishC Qalthos danielmellado ganeshrn justjais trishnaguha
-  team_scaleway: DenBeke QuentinBrosse abarbare jerome-quere kindermoumoute remyleo
+  team_scaleway: abarbare kindermoumoute remyleo

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -374,4 +374,4 @@ macros:
   team_netscaler: chiradeep giorgos-nikolopoulos
   team_netvisor: Qalthos amitsi csharpe-pn pdam preetiparasar
   team_networking: NilashishC Qalthos danielmellado ganeshrn justjais trishnaguha
-  team_scaleway: abarbare kindermoumoute remyleone
+  team_scaleway: abarbare remyleone


### PR DESCRIPTION
##### SUMMARY
To stop receiving bot notifications as we are not working at Scaleway anymore. :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- cloud/scaleway

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
