### PR TITLE
[PR #355/6bf4fb81 backport][stable-1] Remove ex scalers from team_scaleway

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -443,4 +443,4 @@ macros:
   team_netvisor: Qalthos amitsi csharpe-pn pdam preetiparasar
   team_networking: NilashishC Qalthos danielmellado ganeshrn justjais trishnaguha
   team_nso: cmoberg cnasten tbjurman
-  team_scaleway: DenBeke QuentinBrosse abarbare jerome-quere kindermoumoute remyleo
+  team_scaleway: abarbare remyleone


### PR DESCRIPTION
**This is a backport of PR #355 as merged into main (6bf4fb814abcbbea87b5fb8da96e77814ce9f57c).**

##### SUMMARY
To stop receiving bot notifications as we are not working at Scaleway anymore. :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- cloud/scaleway

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
