### PR TITLE
[stable-2] Restrict testing from devel to 2.13

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -42,14 +42,14 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
+  - stage: Sanity_2_13
+    displayName: Sanity 2.13
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
+          testFormat: 2.13/sanity/{0}
           targets:
             - test: 1
             - test: 2
@@ -118,14 +118,14 @@ stages:
             - test: 4
             - test: 5
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
+  - stage: Units_2_13
+    displayName: Units 2.13
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
+          testFormat: 2.13/units/{0}/1
           targets:
             - test: 3.8
             - test: 3.9
@@ -192,14 +192,14 @@ stages:
             - test: 3.7
             - test: 3.8
 ### Cloud
-  - stage: Cloud_devel
-    displayName: Cloud devel
+  - stage: Cloud_2_13
+    displayName: Cloud 2.13
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/cloud/{0}/1
+          testFormat: 2.13/cloud/{0}/1
           targets:
             - test: 3.8
             - test: 3.9
@@ -254,17 +254,17 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
+      - Sanity_2_13
       - Sanity_2_12
       - Sanity_2_11
       - Sanity_2_10
       - Sanity_2_9
-      - Units_devel
+      - Units_2_13
       - Units_2_12
       - Units_2_11
       - Units_2_10
       - Units_2_9
-      - Cloud_devel
+      - Cloud_2_13
       - Cloud_2_12
       - Cloud_2_11
       - Cloud_2_10

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more information about communication, refer to the [Ansible communication gu
 
 ## Tested with Ansible
 
-Tested with the Ansible 2.9, 2.10, 2.11 releases, and the current development version of Ansible. Ansible versions before 2.9.10 are not supported.
+Tested with the Ansible 2.9, 2.10, 2.11, 2.12, and 2.13 releases. Ansible versions before 2.9.10 are not supported.
 
 ### Supported connections
 The community network collection supports `network_cli`  and `httpapi` connections.


### PR DESCRIPTION
##### SUMMARY
devel is already going to 2.14, so let's simply replace devel by 2.13 in the CI config. After all stable-2 is going to be EOL not too far in the future.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
