### PR TITLE
icx_vlan - add stack and modules - fix purge with aggregate

### DIFF
--- a/plugins/modules/network/icx/icx_vlan.py
+++ b/plugins/modules/network/icx/icx_vlan.py
@@ -595,7 +595,6 @@ def map_obj_to_commands(updates, module):
                 commands = []
 
     if purge:
-        commands = []
         vlans = parse_vlan_id(module)
         for h in vlans:
             obj_in_want = search_obj_in_list(h, want)

--- a/plugins/modules/network/icx/icx_vlan.py
+++ b/plugins/modules/network/icx/icx_vlan.py
@@ -329,12 +329,12 @@ def parse_vlan_brief(module, vlan_id):
             del lags[0]
             for port in ports:
                 if "to" in port:
-                    p = port.split(" to ")
+                    p = port.strip().split(" to ")
                     pr = int(p[1].split('/')[2]) - int(p[0].split('/')[2])
                     for i in range(0, pr + 1):
-                        tagged_ports.append((int(p[0].split('/')[2]) + i))
+                        tagged_ports.append(p[0][0:4] + str(int(p[0].split('/')[2]) + i))
                 else:
-                    tagged_ports.append(int(port.split('/')[2]))
+                    tagged_ports.append(port.strip())
             for lag in lags:
                 if "to" in lag:
                     l = lag.split(" to ")
@@ -350,12 +350,12 @@ def parse_vlan_brief(module, vlan_id):
             del lags[0]
             for port in ports:
                 if "to" in port:
-                    p = port.split(" to ")
+                    p = port.strip().split(" to ")
                     pr = int(p[1].split('/')[2]) - int(p[0].split('/')[2])
                     for i in range(0, pr + 1):
-                        untagged_ports.append((int(p[0].split('/')[2]) + i))
+                        untagged_ports.append(p[0][0:4] + str(int(p[0].split('/')[2]) + i))
                 else:
-                    untagged_ports.append(int(port.split('/')[2]))
+                    untagged_ports.append(port.strip())
             for lag in lags:
                 if "to" in lag:
                     l = lag.split(" to ")
@@ -534,7 +534,9 @@ def map_obj_to_commands(updates, module):
 
                             while(high >= low):
                                 if 'ethernet' in interface:
-                                    have_interfaces.append('ethernet 1/1/{0}'.format(low))
+                                    have_interfaces.append(
+                                        'ethernet ' + interface.split(" ")[1].split("/")[0] + '/' + interface.split(" ")[1].split("/")[1] + '/{0}'.format(low)
+                                    )
                                 if 'lag' in interface:
                                     have_interfaces.append('lag {0}'.format(low))
                                 low = low + 1
@@ -557,7 +559,9 @@ def map_obj_to_commands(updates, module):
 
                             while(high >= low):
                                 if 'ethernet' in tag:
-                                    have_tagged.append('ethernet 1/1/{0}'.format(low))
+                                    have_tagged.append(
+                                        'ethernet ' + tag.split(" ")[1].split("/")[0] + '/' + tag.split(" ")[1].split("/")[1] + '/{0}'.format(low)
+                                    )
                                 if 'lag' in tag:
                                     have_tagged.append('lag {0}'.format(low))
                                 low = low + 1
@@ -615,7 +619,7 @@ def parse_interfaces_argument(module, item, port_type):
     if port_type == "interfaces":
         if untagged_ports:
             for port in untagged_ports:
-                ports.append('ethernet 1/1/' + str(port))
+                ports.append('ethernet ' + port)
         if untagged_lags:
             for port in untagged_lags:
                 ports.append('lag ' + str(port))
@@ -623,7 +627,7 @@ def parse_interfaces_argument(module, item, port_type):
     elif port_type == "tagged":
         if tagged_ports:
             for port in tagged_ports:
-                ports.append('ethernet 1/1/' + str(port))
+                ports.append('ethernet ' + port)
         if tagged_lags:
             for port in tagged_lags:
                 ports.append('lag ' + str(port))


### PR DESCRIPTION
##### SUMMARY
Remove the hardcoded  "ethernet 1/1/" to allow stack and modules to work.
Fix module not adding interfaces when purge = true with aggregate
"Fixes #268"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
icx_vlan

##### ADDITIONAL INFORMATION
Picked up on PR#279 which seems to be abandoned.
I use [ratneshnagori](https://github.com/ratneshnagori) work and made a few tweaks to make it works. 
I'll add the changelog fragment when the PR number will be generated. 
I can't see the CI failures on the other PR because it's too old. Maybe it need some more adjustments. 
Be kind, it's my first PR.. ever.
