### PR TITLE
[4.0.0] Add sanity check for non-regular files in plugins/

### DIFF
--- a/tests/sanity/extra/no-unwanted-files.py
+++ b/tests/sanity/extra/no-unwanted-files.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import os.path
 import sys
 
 
@@ -32,6 +33,11 @@ def main():
 
         if any(path.startswith(skip_directory) for skip_directory in skip_directories):
             continue
+
+        if os.path.islink(path):
+            print('%s: is a symbolic link' % (path, ))
+        elif not os.path.isfile(path):
+            print('%s: is not a regular file' % (path, ))
 
         ext = os.path.splitext(path)[1]
 

--- a/tests/sanity/extra/no-unwanted-files.py
+++ b/tests/sanity/extra/no-unwanted-files.py
@@ -27,6 +27,11 @@ def main():
     skip_directories = (
     )
 
+    yaml_directories = (
+        'plugins/test/',
+        'plugins/filter/',
+    )
+
     for path in paths:
         if path in skip_paths:
             continue
@@ -40,6 +45,9 @@ def main():
             print('%s: is not a regular file' % (path, ))
 
         ext = os.path.splitext(path)[1]
+
+        if ext in ('.yml', ) and any(path.startswith(yaml_directory) for yaml_directory in yaml_directories):
+            continue
 
         if ext not in allowed_extensions:
             print('%s: extension must be one of: %s' % (path, ', '.join(allowed_extensions)))


### PR DESCRIPTION
##### SUMMARY
Follow-up to #426, will fail until that one is merged. It will report all symlinks or other non-regular files in plugins/.

I also included support for `.yml` files in plugins/test/ and plugins/filter/ for the upcoming sidecar docs feature of ansible-core 2.14 (https://github.com/ansible/ansible/pull/74963). Not sure whether this is really needed, but if someone ever wants to add test and filter plugins to this collection, it will save them some pain :)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
