### PR TITLE
Updated tests/utils/shippable/shippable.sh to drop ansible-galaxy support

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -80,7 +80,9 @@ patch --forward "${ANSIBLE_DIR}/galaxy/api.py" "tests/utils/shippable/collection
 # END: page_size patch
 
 # START: HACK install dependencies
-retry ansible-galaxy -vvv collection install ansible.netcommon
+retry git clone --depth=1 --single-branch
+https://github.com/ansible-collections/ansible.netcommon.git
+"${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/netcommon"
 
 # END: HACK
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -80,9 +80,7 @@ patch --forward "${ANSIBLE_DIR}/galaxy/api.py" "tests/utils/shippable/collection
 # END: page_size patch
 
 # START: HACK install dependencies
-retry git clone --depth=1 --single-branch
-https://github.com/ansible-collections/ansible.netcommon.git
-"${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/netcommon"
+retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.netcommon.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/netcommon"
 
 # END: HACK
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -81,6 +81,7 @@ patch --forward "${ANSIBLE_DIR}/galaxy/api.py" "tests/utils/shippable/collection
 
 # START: HACK install dependencies
 retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.netcommon.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/netcommon"
+retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.utils.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/utils"
 
 # END: HACK
 


### PR DESCRIPTION
Updated tests/utils/shippable/shippable.sh to drop ansible-galaxy support and using git to install dependency collection.