### PR TITLE
Add `loadkey` command

### DIFF
--- a/plugins/modules/network/edgeos/edgeos_config.py
+++ b/plugins/modules/network/edgeos/edgeos_config.py
@@ -149,10 +149,11 @@ from ansible_collections.community.network.plugins.module_utils.network.edgeos.e
 DEFAULT_COMMENT = 'configured by edgeos_config'
 SET_CMD = 'set '
 DELETE_CMD = 'delete '
+LOADKEY_CMD = 'loadkey '
 
 
 def config_to_commands(config):
-    set_format = config.startswith(SET_CMD) or config.startswith(DELETE_CMD)
+    set_format = config.startswith(SET_CMD) or config.startswith(DELETE_CMD) or config.startswith(LOADKEY_CMD)
     candidate = NetworkConfig(indent=4, contents=config)
     if not set_format:
         candidate = [c.line for c in candidate.items]


### PR DESCRIPTION
##### SUMMARY
Adds support for the `loadkey` command, used to configure ssh key based auth:
https://community.ui.com/questions/Its-not-clear-to-me-how-to-get-the-ssh-key-onto-the-client-from-the-er-x-can-you-help-me/30daf749-4da6-40d5-8999-0c853dc61cde#answer/80d86d0b-b948-41ad-a60f-c720e0ad15cd

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
N/A