### PR TITLE
exos_config: fix used-before-assignment: Using variables before and after before assignment

### DIFF
--- a/plugins/modules/exos_config.py
+++ b/plugins/modules/exos_config.py
@@ -412,6 +412,8 @@ def main():
             base_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
 
             if running_config.sha1 != base_config.sha1:
+                before = ''
+                after = ''
                 if module.params['diff_against'] == 'intended':
                     before = running_config
                     after = base_config


### PR DESCRIPTION


##### SUMMARY
exos_config: fix used-before-assignment: Using variables before and after before assignment

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/exos_config.py