### PR TITLE
lint: fix some violations and add initial config

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,11 @@
+skip_list:
+  # Remove these temporary disable skips added during adopting of ansible-lint:
+  - deprecated-module
+  - fqcn
+  - ignore-errors
+  - jinja
+  - key-order
+  - name
+  - no-free-form
+  - sanity
+  - yaml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,9 +4,10 @@ version: 5.1.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)
-description: null
+description: |
+  This repository contains the `community.network` Ansible Collection. The collection is a part of the `ansible` package and includes many network modules and plugins supported by Ansible community which are not part of more specialized community collections.
 license_file: COPYING
-tags: [community, network]
+tags: [community, networking]
 # NOTE: No more dependencies can be added to this list
 dependencies:
   ansible.netcommon: '>=1.0.0'

--- a/tests/integration/targets/cnos_conditional_template/tasks/main.yml
+++ b/tests/integration/targets/cnos_conditional_template/tasks/main.yml
@@ -6,11 +6,11 @@
 # This contain sample conditional template execution tasks
 ---
 - name: Replace Config CLI command template with values
-  template: src=demo_template.j2 dest=./commands/cnos_conditional_template_{{ inventory_hostname }}_command.txt
+  template: src=demo_template.j2 dest=./commands/cnos_conditional_template_{{ inventory_hostname }}_command.txt mode=0644
   with_items: "{{conditional_template_data1}}"
 
 - name: Applying CLI commands on Switches
-  cnos_conditional_template: host={{ inventory_hostname }} username={{ hostvars[inventory_hostname]['ansible_ssh_user']}}  password={{ hostvars[inventory_hostname]['ansible_ssh_pass']}} deviceType={{ hostvars[inventory_hostname]['deviceType']}} 
+  cnos_conditional_template: host={{ inventory_hostname }} username={{ hostvars[inventory_hostname]['ansible_ssh_user']}}  password={{ hostvars[inventory_hostname]['ansible_ssh_pass']}} deviceType={{ hostvars[inventory_hostname]['deviceType']}}
    condition={{ hostvars[inventory_hostname]['condition'] }} flag='{{item.flag}}' commandfile=./commands/cnos_conditional_template_{{ inventory_hostname }}_command.txt outputfile=./results/cnos_conditional_template_{{ inventory_hostname }}_output.txt
   with_items: "{{conditional_template_data1}}"
 # Completed file

--- a/tests/integration/targets/cnos_template/tasks/main.yml
+++ b/tests/integration/targets/cnos_template/tasks/main.yml
@@ -6,10 +6,10 @@
 # This contain sample template execution tasks
 ---
 - name: Creates directory
-  file: path=./commands state=directory
+  file: path=./commands state=directory mode=0755
 
 - name: Replace Config CLI command template with values
-  template: src=demo_template.j2 dest=./commands/cnos_template_{{ inventory_hostname }}_commands.txt
+  template: src=demo_template.j2 dest=./commands/cnos_template_{{ inventory_hostname }}_commands.txt mode=0644
   with_items: "{{cnos_template_data}}"
 
 - name: Applying CLI commands on Switches

--- a/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
@@ -10,6 +10,7 @@
 
     - name: Start Nuage VSD API Simulator
       shell: "(cd /; nuage-vsd-sim >/dev/null 2>&1)"
+      changed_when: false
       async: 1800
       poll: 0
 


### PR DESCRIPTION
- Fixes 3 simple violations reported by linter
- Introduce initial config that disables some rules that we did
  not fix yet. We will fix these in follow-ups one by one.

Related: https://github.com/ansible/ansible-lint/issues/3482