### PR TITLE
Fix gather_network_resources documentation for exos_facts

### DIFF
--- a/plugins/modules/exos_facts.py
+++ b/plugins/modules/exos_facts.py
@@ -56,7 +56,7 @@ options:
         Can specify a list of values to include a larger subset.
         Values can also be used with an initial C(!) to specify that
         a specific subset should not be collected.
-        Valid subsets are 'all', 'lldp_global'.
+        Valid subsets are 'all', 'lldp_global', 'lldp_interfaces', 'vlans', 'l2_interfaces'.
     type: list
 '''
 
@@ -83,13 +83,13 @@ EXAMPLES = """
       gather_subset:
         - '!all'
         - '!min'
-      gather_network_resource:
+      gather_network_resources:
         - lldp_global
 
   - name: Gather lldp global resource and minimal legacy facts
     community.network.exos_facts:
       gather_subset: min
-      gather_network_resource: lldp_global
+      gather_network_resources: lldp_global
 """
 
 RETURN = """

--- a/plugins/modules/exos_facts.py
+++ b/plugins/modules/exos_facts.py
@@ -36,6 +36,9 @@ description:
     enable or disable collection of additional facts.
 notes:
   - Tested against EXOS 22.5.1.7
+  - `gather_network_resources` currently only works with
+    `ansible_connection: ansible.netcommon.httpapi`. For details see
+    https://github.com/ansible-collections/community.network/issues/460
 options:
   gather_subset:
     description:
@@ -56,7 +59,8 @@ options:
         Can specify a list of values to include a larger subset.
         Values can also be used with an initial C(!) to specify that
         a specific subset should not be collected.
-        Valid subsets are 'all', 'lldp_global', 'lldp_interfaces', 'vlans', 'l2_interfaces'.
+        Valid subsets are 'all', 'lldp_global', 'lldp_interfaces',
+        'vlans', 'l2_interfaces'.
     type: list
 '''
 

--- a/plugins/modules/exos_facts.py
+++ b/plugins/modules/exos_facts.py
@@ -36,9 +36,9 @@ description:
     enable or disable collection of additional facts.
 notes:
   - Tested against EXOS 22.5.1.7
-  - `gather_network_resources` currently only works with
-    `ansible_connection: ansible.netcommon.httpapi`. For details see
-    https://github.com/ansible-collections/community.network/issues/460
+  - "The I(gather_network_resources) option currently only works with
+    C(ansible_connection: ansible.netcommon.httpapi). For details, see
+    U(https://github.com/ansible-collections/community.network/issues/460)."
 options:
   gather_subset:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I stumbled upon some errors in the exos_facts documentation. `gather_network_resources` had typos in the exaples.
Also I improved the parameter description for `gather_network_resources`, because not all valid subsets that are defined in the module have been listed in the docs.
Not much, but might help some users.

Also I had the same problem like described in Issue #460 and took a look at it.
I don't currently have time to implement the `gather_network_resources` param for `network_cli`, but I added a note with a fix/workaround and a reference to the issue. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
exos_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
