### PR TITLE
Add A Requirements File To Bring In Dependencies Automatically

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible-pylibssh


### PR DESCRIPTION
##### SUMMARY

* The `aireos` cliconf plugin requires either `ansible-pylibssh` or `paramiko` in versions of Ansible > 2.9
* This adds a `requirements.txt` file that will be automatically picked up by `ansible-builder` when consumers of the collection install it into an EE

Resolves #146 by making it more obvious this collection has a python dependency with newer versions of Ansible.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`community.network.aireos`

##### ADDITIONAL INFORMATION

With the diverse set of modules present in this collection we may encounter situations in the future where we have to either break-out or fix modules to use consistent dependencies.