### PR TITLE
[stable-4] Missing whitespace for exos_config with defaults: True (#516)

### DIFF
--- a/changelogs/fragments/516-whitespace-exos-config-defaults.yaml
+++ b/changelogs/fragments/516-whitespace-exos-config-defaults.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "exos_config - missing whitespace in command with ``defaults: True``. It happened because the command is ``show configurationdetail`` instead of ``show configuration detail`` (https://github.com/ansible-collections/community.network/pull/516)."

--- a/plugins/modules/network/exos/exos_config.py
+++ b/plugins/modules/network/exos/exos_config.py
@@ -323,7 +323,7 @@ def main():
         result['warnings'] = warnings
 
     config = None
-    flags = ['detail'] if module.params['defaults'] else []
+    flags = [' detail'] if module.params['defaults'] else []
     diff_ignore_lines = module.params['diff_ignore_lines']
 
     if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):


### PR DESCRIPTION


Co-authored-by: Yannis Ansermoz <yannis.ansermoz@edificom.ch>
Co-authored-by: Andrew Klychkov <aaklychkov@mail.ru>
(cherry picked from commit 18340ef55e566ac49921ae139d2383350fea5a06)

##### SUMMARY
Backport of https://github.com/ansible-collections/community.network/pull/516