### PR TITLE
Sanity: # shellcheck disable=SC2153

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -62,6 +62,7 @@ else
     retry pip install "https://github.com/ansible/ansible/archive/stable-${ansible_version}.tar.gz" --disable-pip-version-check
 fi
 
+# shellcheck disable=SC2153
 if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
     export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
     SHIPPABLE_RESULT_DIR="$(pwd)/shippable"


### PR DESCRIPTION
##### SUMMARY
To ignore the error "tests/utils/shippable/shippable.sh:70:13: SC2153: Possible misspelling: SHIPPABLE_BUILD_DIR may not be assigned. Did you mean SHIPPABLE_BUILD_ID"

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
tests/utils/shippable/shippable.sh
